### PR TITLE
Reset configuration file to default if the file is empty

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"bytes"
 
 	"github.com/sirupsen/logrus"
 )
@@ -47,14 +48,27 @@ func saveConfig() error {
 	return os.WriteFile(configPath, b, 0644)
 }
 
+func resetConfig() error {
+	config = defaultConfig
+
+	logrus.WithFields(logrus.Fields{
+		"config": defaultConfig,
+		"config_file": configPath,
+	}).Warn("resetting config file to default")
+
+	err := saveConfig()
+	return err
+}
+
 func loadConfig() error {
 	// Check if config file exists
 	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
-		logrus.WithField("config", defaultConfig).Infof("config file %s does not exist, using default config", configPath)
-		config = defaultConfig
-		err := saveConfig()
+		logrus.WithFields(logrus.Fields{
+			"config_file": configPath,
+		}).Warn("config file does not exist")
+
+		err = resetConfig()
 		if err != nil {
-			logrus.Errorf("failed to save config: %v", err)
 			return err
 		}
 	}
@@ -63,5 +77,23 @@ func loadConfig() error {
 	if err != nil {
 		return err
 	}
+
+	if len(bytes.TrimSpace(b)) == 0 {
+		logrus.WithFields(logrus.Fields{
+			"config_file": configPath,
+			"config_bytes": b,
+		}).Warn("config file is empty")
+
+		err = resetConfig()
+		if err != nil {
+			return err
+		}
+
+		b, err = os.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	return json.Unmarshal(b, &config)
 }

--- a/daemon.go
+++ b/daemon.go
@@ -54,7 +54,7 @@ func runDaemon() {
 
 	err := loadConfig()
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Fatalf("failed to parse config during startup: %v", err)
 	}
 	logrus.Infof("config loaded: %#v", config)
 

--- a/nonbrew.go
+++ b/nonbrew.go
@@ -30,7 +30,7 @@ By default, only root user is allowed to access the batt daemon for security rea
 
 			err := loadConfig()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse config during installation: %v", err)
 			}
 
 			flags := cmd.Flags()


### PR DESCRIPTION
I encountered a weird case where I ended up with an empty configuration file, which caused `json.Unmarshal` to fail. This guards against that by resetting the configuration file to the defaults whenever this situation occurs. There's also some refactoring and logging improvements to catch when configuration-related errors occur.