### PR TITLE
feat: add smc keys for macos tahoe

### DIFF
--- a/pkg/smc/adapter.go
+++ b/pkg/smc/adapter.go
@@ -6,7 +6,7 @@ import "github.com/sirupsen/logrus"
 func (c *AppleSMC) IsAdapterEnabled() (bool, error) {
 	logrus.Tracef("IsAdapterEnabled called")
 
-	v, err := c.Read(AdapterKey)
+	v, err := c.Read(AdapterKey1)
 	if err != nil {
 		return false, err
 	}
@@ -21,12 +21,12 @@ func (c *AppleSMC) IsAdapterEnabled() (bool, error) {
 func (c *AppleSMC) EnableAdapter() error {
 	logrus.Tracef("EnableAdapter called")
 
-	return c.Write(AdapterKey, []byte{0x0})
+	return c.Write(AdapterKey1, []byte{0x0})
 }
 
 // DisableAdapter disables the adapter.
 func (c *AppleSMC) DisableAdapter() error {
 	logrus.Tracef("DisableAdapter called")
 
-	return c.Write(AdapterKey, []byte{0x1})
+	return c.Write(AdapterKey1, []byte{0x1})
 }

--- a/pkg/smc/consts_arm64.go
+++ b/pkg/smc/consts_arm64.go
@@ -6,6 +6,19 @@ const (
 	ACPowerKey       = "AC-W"
 	ChargingKey1     = "CH0B"
 	ChargingKey2     = "CH0C"
-	AdapterKey       = "CH0I" // CH0K on Intel, if we need it later
+	ChargingKey3     = "CHTE"
+	AdapterKey1      = "CH0I"
+	AdapterKey2      = "CH0J"
 	BatteryChargeKey = "BUIC"
 )
+
+var allKeys = []string{
+	MagSafeLedKey,
+	ACPowerKey,
+	ChargingKey1,
+	ChargingKey2,
+	ChargingKey3,
+	AdapterKey1,
+	AdapterKey2,
+	BatteryChargeKey,
+}


### PR DESCRIPTION
See #34

Should be backwards compatible.