### PR TITLE
feat: add `always-off` option to MagSafe LED control

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GUI version is a native macOS menubar app. It's not as feature-complete as the c
 1. Download `.dmg` file from [Releases](https://github.com/charlie0129/batt/releases) and open it (right-click open if macOS says it's damaged)
 2. Drag `batt.app` to `Applications`
 3. macOS may say it's damaged when you try to run it (it's NOT) and wants you to move it to trash. To fix it, run this in Terminal: `sudo xattr -r -d com.apple.quarantine /Applications/batt.app`.
-4. Run `batt.app`. 
+4. Run `batt.app`.
 5. Follow the MenuBar UI to install or upgrade.
 6. It is _highly_ recommended to disable macOS's optimized charging when using `batt`. To do so, open `System Settings` -> `Battery` -> `Battery Health` -> `i` -> Turn OFF `Optimized Battery Charging`
 
@@ -109,7 +109,7 @@ You can choose either one. Please do not use both at the same time to avoid conf
 1. (Optional) There is an installation script to help you quickly install batt (Internet connection required). Put this in your terminal: `bash <(curl -fsSL https://github.com/charlie0129/batt/raw/master/hack/install.sh)`. You may need to provide your login password (to control charging). This will download and install the latest _stable_ version for you. Follow the on-screen instructions, then you can skip to step 5.
 <details>
 <summary>Manual installation steps</summary>
-    
+
 2. Get the binary. For _stable_ and _beta_ releases, you can find the download link in the [release page](https://github.com/charlie0129/batt/releases). If you want development versions with the latest features and bug fixes, you can download prebuilt binaries from [GitHub Actions](https://github.com/charlie0129/batt/actions/workflows/build-test-binary.yml) (has a retention period of 3 months and you need to `chmod +x batt` after extracting the archive) or [build it yourself](#building) .
 3. Put the binary somewhere safe. You don't want to move it after installation :). It is recommended to save it in your `$PATH`, e.g., `/usr/local/bin`, so you can directly call `batt` on the command-line. In this case, the binary location will be `/usr/local/bin/batt`.
 4. Install daemon using `sudo batt install`. If you do not want to use `sudo` every time after installation, add the `--allow-non-root-access` flag: `sudo batt install --allow-non-root-access`. To uninstall: please refer to [How to uninstall?](#how-to-uninstall)
@@ -143,10 +143,10 @@ To customize charge limit, see `batt limit`. For example,to set the limit to 80%
 
 ### Enable/disable power adapter
 
-> [!NOTE]  
+> [!NOTE]
 > This feature is CLI-only and is not available in the GUI version.
 
-Cut or restore power from the wall. This has the same effect as unplugging/plugging the power adapter, even if the adapter is physically plugged in. 
+Cut or restore power from the wall. This has the same effect as unplugging/plugging the power adapter, even if the adapter is physically plugged in.
 
 This is useful when you want to use your battery to lower the battery charge, but you don't want to unplug the power adapter.
 
@@ -156,7 +156,7 @@ To enable/disable power adapter, see `batt adapter`. For example, to disable the
 
 ### Check status
 
-> [!NOTE]  
+> [!NOTE]
 > This feature is CLI-only and is not available in the GUI version.
 
 Check the current config, battery info, and charging status.
@@ -207,7 +207,7 @@ To enable this feature, run `sudo batt prevent-system-sleep enable`. To disable,
 
 ### Upper and lower charge limit
 
-> [!NOTE]  
+> [!NOTE]
 > This feature is CLI-only and is not available in the GUI version.
 
 When you set a charge limit, for example, on a Lenovo ThinkPad, you can set two percentages. The first one is the upper limit, and the second one is the lower limit. When the battery charge is above the upper limit, the computer will stop charging. When the battery charge is below the lower limit, the computer will start charging. If the battery charge is between the two limits, the computer will keep whatever charging state it is in.
@@ -220,7 +220,7 @@ For example, if you want to set the lower limit to be 5% less than the upper lim
 
 > Acknowledgement: [@exidler](https://github.com/exidler)
 
-This option can make the MagSafe LED on your MacBook change color according to the charging status. For example: 
+This option makes the MagSafe LED reflect the charging state of your MacBook (or force it off).
 
 - Green: charge limit is reached and charging is stopped.
 - Orange: charging is in progress.
@@ -229,6 +229,8 @@ This option can make the MagSafe LED on your MacBook change color according to t
 Note that you must have a MagSafe LED on your MacBook to use this feature.
 
 To enable MagSafe LED control, run `sudo batt magsafe-led enable`.
+
+To force the MagSafe LED to stay off, run `sudo batt magsafe-led always-off`.
 
 ### Check logs
 

--- a/cmd/batt/advanced.go
+++ b/cmd/batt/advanced.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
+
+	"github.com/charlie0129/batt/pkg/config"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func NewSetPreventIdleSleepCommand() *cobra.Command {
@@ -56,9 +58,9 @@ Note: please disable disable-charging-pre-sleep and prevent-idle-sleep, while th
 func NewSetControlMagSafeLEDCommand() *cobra.Command {
 	use := "magsafe-led"
 	cmd := &cobra.Command{
-		Use: use,
+		Use:     use,
 		GroupID: gAdvanced,
-		Short: "Control MagSafe LED according to battery charging status",
+		Short:   "Control MagSafe LED according to battery charging status",
 	}
 
 	enable := &cobra.Command{
@@ -68,7 +70,7 @@ func NewSetControlMagSafeLEDCommand() *cobra.Command {
 		- Orange: Charging is in progress.
 		- Off: Woke from sleep, charging is off and batt is awaiting control.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			ret, err := apiClient.SetControlMagSafeLED("enable")
+			ret, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeEnabled)
 			if err != nil {
 				return fmt.Errorf("failed to set to %s: %v", use, err)
 			}
@@ -81,10 +83,10 @@ func NewSetControlMagSafeLEDCommand() *cobra.Command {
 	}
 
 	disable := &cobra.Command{
-		Use: "disable",
+		Use:   "disable",
 		Short: "Disable MagSafe LED control.",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			ret, err := apiClient.SetControlMagSafeLED("disable")
+			ret, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeDisabled)
 			if err != nil {
 				return fmt.Errorf("failed to set to %s: %v", use, err)
 			}
@@ -97,10 +99,10 @@ func NewSetControlMagSafeLEDCommand() *cobra.Command {
 	}
 
 	alwaysOff := &cobra.Command{
-		Use: "always-off",
+		Use:   "always-off",
 		Short: "Force the MagSafe LED to stay off.",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			ret, err := apiClient.SetControlMagSafeLED("always-off")
+			ret, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeAlwaysOff)
 			if err != nil {
 				return fmt.Errorf("failed to set to %s: %v", use, err)
 			}

--- a/cmd/batt/status.go
+++ b/cmd/batt/status.go
@@ -193,7 +193,7 @@ func NewStatusCommand() *cobra.Command {
 			cmd.Printf("  Disable charging before sleep if charge limit is enabled: %s\n", bool2Text(config.DisableChargingPreSleep()))
 			cmd.Printf("  Prevent system-sleep when charging: %s\n", bool2Text(config.PreventSystemSleep()))
 			cmd.Printf("  Allow non-root users to access the daemon: %s\n", bool2Text(config.AllowNonRootAccess()))
-			cmd.Printf("  Control MagSafe LED: %s\n", bool2Text(config.ControlMagSafeLED()))
+			cmd.Printf("  Control MagSafe LED: %s\n", bold("%s", config.ControlMagSafeLED()))
 			return nil
 		},
 	}

--- a/pkg/client/apis.go
+++ b/pkg/client/apis.go
@@ -43,8 +43,12 @@ func (c *Client) SetPreventSystemSleep(enabled bool) (string, error) {
 	return c.Put("/prevent-system-sleep", strconv.FormatBool(enabled))
 }
 
-func (c *Client) SetControlMagSafeLED(enabled bool) (string, error) {
-	return c.Put("/magsafe-led", strconv.FormatBool(enabled))
+func (c *Client) SetControlMagSafeLED(mode string) (string, error) {
+	payload, err := json.Marshal(mode)
+    if err != nil {
+        return "", err
+    }
+    return c.Put("/magsafe-led", string(payload))
 }
 
 func (c *Client) GetCharging() (bool, error) {

--- a/pkg/client/apis.go
+++ b/pkg/client/apis.go
@@ -43,12 +43,12 @@ func (c *Client) SetPreventSystemSleep(enabled bool) (string, error) {
 	return c.Put("/prevent-system-sleep", strconv.FormatBool(enabled))
 }
 
-func (c *Client) SetControlMagSafeLED(mode string) (string, error) {
+func (c *Client) SetControlMagSafeLED(mode config.ControlMagSafeMode) (string, error) {
 	payload, err := json.Marshal(mode)
-    if err != nil {
-        return "", err
-    }
-    return c.Put("/magsafe-led", string(payload))
+	if err != nil {
+		return "", err
+	}
+	return c.Put("/magsafe-led", string(payload))
 }
 
 func (c *Client) GetCharging() (bool, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@ type Config interface {
 	DisableChargingPreSleep() bool
 	PreventSystemSleep() bool
 	AllowNonRootAccess() bool
-	ControlMagSafeLED() bool
+	ControlMagSafeLED() string
 
 	SetUpperLimit(int)
 	SetLowerLimit(int)
@@ -19,7 +19,7 @@ type Config interface {
 	SetDisableChargingPreSleep(bool)
 	SetPreventSystemSleep(bool)
 	SetAllowNonRootAccess(bool)
-	SetControlMagSafeLED(bool)
+	SetControlMagSafeLED(string)
 
 	LogrusFields() logrus.Fields
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@ type Config interface {
 	DisableChargingPreSleep() bool
 	PreventSystemSleep() bool
 	AllowNonRootAccess() bool
-	ControlMagSafeLED() string
+	ControlMagSafeLED() ControlMagSafeMode
 
 	SetUpperLimit(int)
 	SetLowerLimit(int)
@@ -19,7 +19,7 @@ type Config interface {
 	SetDisableChargingPreSleep(bool)
 	SetPreventSystemSleep(bool)
 	SetAllowNonRootAccess(bool)
-	SetControlMagSafeLED(string)
+	SetControlMagSafeLED(ControlMagSafeMode)
 
 	LogrusFields() logrus.Fields
 

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -13,6 +13,8 @@ import (
 	"github.com/charlie0129/batt/pkg/utils/ptr"
 )
 
+type ControlMagSafeMode string
+
 var (
 	defaultFileConfig = &RawFileConfig{
 		Limit:                   ptr.To(80),
@@ -24,7 +26,7 @@ var (
 		// There are Macs without MagSafe LED. We only do checks when the user
 		// explicitly enables this feature. In the future, we might add a check
 		// that disables this feature if the Mac does not have a MagSafe LED.
-		ControlMagSafeLED: ptr.To(false),
+		ControlMagSafeLED:       ptr.To(ControlMagSafeMode("disable")),
 	}
 )
 
@@ -63,14 +65,32 @@ func NewFileFromConfig(c *RawFileConfig, configPath string) *File {
 	return f
 }
 
+func (c *ControlMagSafeMode) UnmarshalJSON(data []byte) error {
+    var s string
+    if err := json.Unmarshal(data, &s); err == nil {
+        *c = ControlMagSafeMode(s)
+        return nil
+    }
+    var b bool
+    if err := json.Unmarshal(data, &b); err == nil {
+        if b {
+            *c = "enable"
+        } else {
+            *c = "disable"
+        }
+        return nil
+    }
+    return nil
+}
+
 type RawFileConfig struct {
-	Limit                   *int  `json:"limit,omitempty"`
-	PreventIdleSleep        *bool `json:"preventIdleSleep,omitempty"`
-	DisableChargingPreSleep *bool `json:"disableChargingPreSleep,omitempty"`
-	PreventSystemSleep      *bool `json:"preventSystemSleep,omitempty"`
-	AllowNonRootAccess      *bool `json:"allowNonRootAccess,omitempty"`
-	LowerLimitDelta         *int  `json:"lowerLimitDelta,omitempty"`
-	ControlMagSafeLED       *bool `json:"controlMagSafeLED,omitempty"`
+	Limit                   *int                `json:"limit,omitempty"`
+	PreventIdleSleep        *bool               `json:"preventIdleSleep,omitempty"`
+	DisableChargingPreSleep *bool               `json:"disableChargingPreSleep,omitempty"`
+	PreventSystemSleep      *bool               `json:"preventSystemSleep,omitempty"`
+	AllowNonRootAccess      *bool               `json:"allowNonRootAccess,omitempty"`
+	LowerLimitDelta         *int                `json:"lowerLimitDelta,omitempty"`
+	ControlMagSafeLED       *ControlMagSafeMode	`json:"controlMagSafeLED,omitempty"`
 }
 
 func NewRawFileConfigFromConfig(c Config) (*RawFileConfig, error) {
@@ -85,7 +105,7 @@ func NewRawFileConfigFromConfig(c Config) (*RawFileConfig, error) {
 		PreventSystemSleep:      ptr.To(c.PreventSystemSleep()),
 		AllowNonRootAccess:      ptr.To(c.AllowNonRootAccess()),
 		LowerLimitDelta:         ptr.To(c.UpperLimit() - c.LowerLimit()),
-		ControlMagSafeLED:       ptr.To(c.ControlMagSafeLED()),
+		ControlMagSafeLED:       ptr.To(ControlMagSafeMode(c.ControlMagSafeLED())),
 	}
 
 	return rawConfig, nil
@@ -205,7 +225,7 @@ func (f *File) AllowNonRootAccess() bool {
 	return allowNonRootAccess
 }
 
-func (f *File) ControlMagSafeLED() bool {
+func (f *File) ControlMagSafeLED() string {
 	if f.c == nil {
 		panic("config is nil")
 	}
@@ -213,15 +233,15 @@ func (f *File) ControlMagSafeLED() bool {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	var controlMagSafeLED bool
+	var ControlMagSafeLED ControlMagSafeMode
 
 	if f.c.ControlMagSafeLED != nil {
-		controlMagSafeLED = *f.c.ControlMagSafeLED
+		ControlMagSafeLED = *f.c.ControlMagSafeLED
 	} else {
-		controlMagSafeLED = *defaultFileConfig.ControlMagSafeLED
+		ControlMagSafeLED = *defaultFileConfig.ControlMagSafeLED
 	}
 
-	return controlMagSafeLED
+	return string(ControlMagSafeLED)
 }
 
 func (f *File) SetUpperLimit(i int) {
@@ -296,7 +316,7 @@ func (f *File) SetAllowNonRootAccess(b bool) {
 	f.c.AllowNonRootAccess = &b
 }
 
-func (f *File) SetControlMagSafeLED(b bool) {
+func (f *File) SetControlMagSafeLED(mode string) {
 	if f.c == nil {
 		panic("config is nil")
 	}
@@ -304,7 +324,7 @@ func (f *File) SetControlMagSafeLED(b bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	f.c.ControlMagSafeLED = &b
+	f.c.ControlMagSafeLED = ptr.To(ControlMagSafeMode(mode))
 }
 
 func (f *File) Load() error {

--- a/pkg/daemon/handlers.go
+++ b/pkg/daemon/handlers.go
@@ -285,7 +285,7 @@ func setControlMagSafeLED(c *gin.Context) {
 		return
 	}
 
-	var mode string
+	var mode config.ControlMagSafeMode
 	if err := c.BindJSON(&mode); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)

--- a/pkg/daemon/handlers.go
+++ b/pkg/daemon/handlers.go
@@ -285,14 +285,14 @@ func setControlMagSafeLED(c *gin.Context) {
 		return
 	}
 
-	var d bool
-	if err := c.BindJSON(&d); err != nil {
+	var mode string
+	if err := c.BindJSON(&mode); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 
-	conf.SetControlMagSafeLED(d)
+	conf.SetControlMagSafeLED(mode)
 	if err := conf.Save(); err != nil {
 		logrus.Errorf("saveConfig failed: %v", err)
 		c.IndentedJSON(http.StatusInternalServerError, err.Error())
@@ -300,9 +300,9 @@ func setControlMagSafeLED(c *gin.Context) {
 		return
 	}
 
-	logrus.Infof("set control MagSafe LED to %t", d)
+	logrus.Infof("set control MagSafe LED to %s", mode)
 
-	c.IndentedJSON(http.StatusCreated, fmt.Sprintf("ControlMagSafeLED set to %t. You should be able to see the effect in a few minutes.", d))
+	c.IndentedJSON(http.StatusCreated, fmt.Sprintf("ControlMagSafeLED set to %s. You should be able to see the effect in a few minutes.", mode))
 }
 
 func getCurrentCharge(c *gin.Context) {

--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charlie0129/batt/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -239,9 +240,9 @@ func handleNoMaintain(isChargingEnabled bool) bool {
 			return false
 		}
 		switch conf.ControlMagSafeLED() {
-		case "always-off":
+		case config.ControlMagSafeModeAlwaysOff:
 			_ = smcConn.DisableMagSafeLed()
-		case "enable":
+		case config.ControlMagSafeModeEnabled:
 			batteryCharge, err := smcConn.GetBatteryCharge()
 			if err == nil {
 				_ = smcConn.SetMagSafeCharging(batteryCharge < 100)
@@ -299,9 +300,9 @@ func handleChargingLogic(ignoreMissedLoops, isChargingEnabled, isPluggedIn bool,
 	}
 
 	switch conf.ControlMagSafeLED() {
-	case "always-off":
+	case config.ControlMagSafeModeAlwaysOff:
 		_ = smcConn.DisableMagSafeLed()
-	case "enable":
+	case config.ControlMagSafeModeEnabled:
 		updateMagSafeLed(isChargingEnabled)
 	default:
 		// nothing

--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -238,11 +238,16 @@ func handleNoMaintain(isChargingEnabled bool) bool {
 			logrus.Errorf("EnableCharging failed: %v", err)
 			return false
 		}
-		if conf.ControlMagSafeLED() {
+		switch conf.ControlMagSafeLED() {
+		case "always-off":
+			_ = smcConn.DisableMagSafeLed()
+		case "enable":
 			batteryCharge, err := smcConn.GetBatteryCharge()
 			if err == nil {
 				_ = smcConn.SetMagSafeCharging(batteryCharge < 100)
 			}
+		default:
+			// nothing
 		}
 	}
 	maintainedChargingInProgress = false
@@ -293,8 +298,13 @@ func handleChargingLogic(ignoreMissedLoops, isChargingEnabled, isPluggedIn bool,
 		maintainedChargingInProgress = false
 	}
 
-	if conf.ControlMagSafeLED() {
+	switch conf.ControlMagSafeLED() {
+	case "always-off":
+		_ = smcConn.DisableMagSafeLed()
+	case "enable":
 		updateMagSafeLed(isChargingEnabled)
+	default:
+		// nothing
 	}
 
 	if conf.PreventSystemSleep() {

--- a/pkg/daemon/sleepcallback.go
+++ b/pkg/daemon/sleepcallback.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charlie0129/batt/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -115,7 +116,7 @@ func systemWillSleepCallback() {
 			logrus.Errorf("DisableCharging failed: %v", err)
 			return
 		}
-		if conf.ControlMagSafeLED() != "disable" {
+		if conf.ControlMagSafeLED() != config.ControlMagSafeModeDisabled {
 			err = smcConn.DisableMagSafeLed()
 			if err != nil {
 				logrus.Errorf("DisableMagSafeLed failed: %v", err)
@@ -153,7 +154,7 @@ func systemHasPoweredOnCallback() {
 			logrus.Debugf("delaying next loop by %d seconds", postSleepLoopDelaySeconds)
 			wg.Add(1)
 			go func() {
-				if conf.DisableChargingPreSleep() && conf.ControlMagSafeLED() != "disable" {
+				if conf.DisableChargingPreSleep() && conf.ControlMagSafeLED() != config.ControlMagSafeModeDisabled {
 					err := smcConn.DisableMagSafeLed()
 					if err != nil {
 						logrus.Errorf("DisableMagSafeLed failed: %v", err)

--- a/pkg/daemon/sleepcallback.go
+++ b/pkg/daemon/sleepcallback.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/charlie0129/batt/pkg/smc"
 )
 
 var (
@@ -117,10 +115,10 @@ func systemWillSleepCallback() {
 			logrus.Errorf("DisableCharging failed: %v", err)
 			return
 		}
-		if conf.ControlMagSafeLED() {
-			err = smcConn.SetMagSafeLedState(smc.LEDOff)
+		if conf.ControlMagSafeLED() != "disable" {
+			err = smcConn.DisableMagSafeLed()
 			if err != nil {
-				logrus.Errorf("SetMagSafeLedState failed: %v", err)
+				logrus.Errorf("DisableMagSafeLed failed: %v", err)
 			}
 		}
 	} else {
@@ -155,10 +153,10 @@ func systemHasPoweredOnCallback() {
 			logrus.Debugf("delaying next loop by %d seconds", postSleepLoopDelaySeconds)
 			wg.Add(1)
 			go func() {
-				if conf.DisableChargingPreSleep() && conf.ControlMagSafeLED() {
-					err := smcConn.SetMagSafeLedState(smc.LEDOff)
+				if conf.DisableChargingPreSleep() && conf.ControlMagSafeLED() != "disable" {
+					err := smcConn.DisableMagSafeLed()
 					if err != nil {
-						logrus.Errorf("SetMagSafeLedState failed: %v", err)
+						logrus.Errorf("DisableMagSafeLed failed: %v", err)
 					}
 				}
 

--- a/pkg/gui/cmd.go
+++ b/pkg/gui/cmd.go
@@ -178,7 +178,7 @@ Note that you must have a MagSafe LED on your MacBook to use this feature.`)
 		setCheckboxItem(controlMagSafeDisableItem, false)
 		setCheckboxItem(controlMagSafeAlwaysOffItem, false)
 
-		_, err := apiClient.SetControlMagSafeLED("enable")
+		_, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeEnabled)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to set control mag safe LED")
 			showAlert("Failed to set MagSafe LED control", err.Error())
@@ -192,7 +192,7 @@ Note that you must have a MagSafe LED on your MacBook to use this feature.`)
 		setCheckboxItem(controlMagSafeDisableItem, true)
 		setCheckboxItem(controlMagSafeAlwaysOffItem, false)
 
-		_, err := apiClient.SetControlMagSafeLED("disable")
+		_, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeDisabled)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to set control mag safe LED")
 			showAlert("Failed to set MagSafe LED control", err.Error())
@@ -206,7 +206,7 @@ Note that you must have a MagSafe LED on your MacBook to use this feature.`)
 		setCheckboxItem(controlMagSafeDisableItem, false)
 		setCheckboxItem(controlMagSafeAlwaysOffItem, true)
 
-		_, err := apiClient.SetControlMagSafeLED("always-off")
+		_, err := apiClient.SetControlMagSafeLED(config.ControlMagSafeModeAlwaysOff)
 		if err != nil {
 			logrus.WithError(err).Error("Failed to set control mag safe LED")
 			showAlert("Failed to set MagSafe LED control", err.Error())
@@ -501,8 +501,8 @@ type menuController struct {
 	setQuickLimitsItems map[int]appkit.MenuItem
 
 	// Advanced
-	advancedSubMenuItem         appkit.MenuItem
-	controlMagSafeLEDItem       appkit.MenuItem
+	advancedSubMenuItem   appkit.MenuItem
+	controlMagSafeLEDItem appkit.MenuItem
 
 	controlMagSafeEnableItem    appkit.MenuItem
 	controlMagSafeDisableItem   appkit.MenuItem
@@ -632,11 +632,11 @@ func (c *menuController) refreshOnOpen() {
 
 	magSafeMode := conf.ControlMagSafeLED()
 	switch magSafeMode {
-	case "enable":
+	case config.ControlMagSafeModeEnabled:
 		setCheckboxItem(c.controlMagSafeEnableItem, true)
 		setCheckboxItem(c.controlMagSafeDisableItem, false)
 		setCheckboxItem(c.controlMagSafeAlwaysOffItem, false)
-	case "always-off":
+	case config.ControlMagSafeModeAlwaysOff:
 		setCheckboxItem(c.controlMagSafeEnableItem, false)
 		setCheckboxItem(c.controlMagSafeDisableItem, false)
 		setCheckboxItem(c.controlMagSafeAlwaysOffItem, true)

--- a/pkg/smc/magsafe.go
+++ b/pkg/smc/magsafe.go
@@ -24,6 +24,12 @@ func (c *AppleSMC) SetMagSafeLedState(state MagSafeLedState) error {
 	return c.Write(MagSafeLedKey, []byte{byte(state)})
 }
 
+func (c *AppleSMC) DisableMagSafeLed() error {
+	logrus.Tracef("DisableMagSafeLed() called")
+
+	return c.Write(MagSafeLedKey, []byte{byte(LEDOff)})
+}
+
 // GetMagSafeLedState .
 func (c *AppleSMC) GetMagSafeLedState() (MagSafeLedState, error) {
 	logrus.Tracef("GetMagSafeLedState called")


### PR DESCRIPTION
This PR adds a third option `always-off` to MagSafe LED control.

* Updated CLI, GUI, client API, daemon and config to handle the three modes (enable, disable, always-off)

* Added JSON unmarshaller for the boolean config field to preserve compatibility.