### PR TITLE
chore: fix incorrect power metrics on M4 Pro chips

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charlie0129/gosmc v0.0.0-20250206014004-02656b3859e0
 	github.com/fatih/color v1.15.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/peterneutron/powerkit-go v0.2.9
+	github.com/peterneutron/powerkit-go v0.3.3
 	github.com/pkg/errors v0.9.1
 	github.com/progrium/darwinkit v0.5.1-0.20240715194340-61b9e31a12fa
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
-github.com/peterneutron/powerkit-go v0.2.9 h1:hufTWo81ik7+IpqIKyPElLKoD94y42NqKdSviulu9yc=
-github.com/peterneutron/powerkit-go v0.2.9/go.mod h1:Bqj3JNxrIavl/qPWlmpz72HZXiglCqnV9juBZBWqfJw=
+github.com/peterneutron/powerkit-go v0.3.3 h1:hHjt9OqHpwRR7SHPmqz7FWK6+6g9TGinapWvUelIR6Q=
+github.com/peterneutron/powerkit-go v0.3.3/go.mod h1:Bqj3JNxrIavl/qPWlmpz72HZXiglCqnV9juBZBWqfJw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
by bumping github.com/peterneutron/powerkit-go to v0.3.3

closes #73