### PR TITLE
fix: direct CLI output to stdout instead of stderr

### DIFF
--- a/cmd/batt/main.go
+++ b/cmd/batt/main.go
@@ -136,6 +136,12 @@ Report issues: https://github.com/charlie0129/batt/issues`,
 		}
 	}
 
+	// Direct cmd.Print* output to stdout instead of the default stderr.
+	// This ensures normal command output (e.g., batt status) goes to stdout,
+	// while only errors and diagnostics go to stderr.
+	// See: https://github.com/charlie0129/batt/issues/120
+	cmd.SetOut(os.Stdout)
+
 	globalFlags := cmd.PersistentFlags()
 	globalFlags.StringVarP(&logLevel, "log-level", "l", logLevel, "log level (trace, debug, info, warn, error, fatal, panic)")
 	globalFlags.StringVar(&configPath, "config", configPath, "config file path")


### PR DESCRIPTION
Fixes #120

## Problem

Cobra's `cmd.Print*` methods default to `os.Stderr` when no output writer is set via `cmd.SetOut()`. This causes commands like `batt status` to write their output to stderr, making redirection (`batt status > file.txt`) capture nothing.

## Fix

Add `cmd.SetOut(os.Stdout)` in `NewCommand()` so all `cmd.Print*` output goes to stdout. Errors and diagnostics (via `fmt.Fprintln(os.Stderr, ...)` and logrus) continue to go to stderr as expected.

This is a one-line fix that resolves the inconsistency described in #120.