### PR TITLE
feat: add `--json` flag to `batt status` for machine-readable output

### DIFF
--- a/cmd/batt/status_json.go
+++ b/cmd/batt/status_json.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/config"
+	"github.com/charlie0129/batt/pkg/powerinfo"
+)
+
+type statusJSON struct {
+	Charging      statusChargingJSON     `json:"charging"`
+	Battery       statusBatteryJSON      `json:"battery"`
+	Configuration statusConfigJSON       `json:"configuration"`
+	// Calibration is omitted when telemetry data is unavailable (e.g. API error).
+	Calibration   *statusCalibrationJSON `json:"calibration,omitempty"`
+}
+
+type statusChargingJSON struct {
+	AllowCharging bool `json:"allowCharging"`
+	UseAdapter    bool `json:"useAdapter"`
+	PluggedIn     bool `json:"pluggedIn"`
+}
+
+type statusBatteryJSON struct {
+	CurrentChargePercent int     `json:"currentChargePercent"`
+	State                string  `json:"state"`
+	TimeToLimitMinutes   *int    `json:"timeToLimitMinutes"`
+	FullCapacityMah      int     `json:"fullCapacityMah"`
+	ChargeRateWatts      float64 `json:"chargeRateWatts"`
+	VoltageVolts         float64 `json:"voltageVolts"`
+}
+
+type statusConfigJSON struct {
+	Enabled                 bool                 `json:"enabled"`
+	UpperLimitPercent       int                  `json:"upperLimitPercent"`
+	LowerLimitPercent       int                  `json:"lowerLimitPercent"`
+	PreventIdleSleep        bool                 `json:"preventIdleSleep"`
+	DisableChargingPreSleep bool                 `json:"disableChargingPreSleep"`
+	PreventSystemSleep      bool                 `json:"preventSystemSleep"`
+	AllowNonRootAccess      bool                 `json:"allowNonRootAccess"`
+	ControlMagSafeLed       statusMagSafeLedJSON `json:"controlMagSafeLed"`
+}
+
+type statusMagSafeLedJSON struct {
+	Enabled bool   `json:"enabled"`
+	Mode    string `json:"mode"`
+}
+
+type statusCalibrationJSON struct {
+	Phase     string                     `json:"phase"`
+	StartedAt *time.Time                 `json:"startedAt"`
+	Paused    bool                       `json:"paused"`
+	CanPause  bool                       `json:"canPause"`
+	CanCancel bool                       `json:"canCancel"`
+	Message   string                     `json:"message"`
+	Schedule  statusCalibrationSchedJSON `json:"schedule"`
+}
+
+type statusCalibrationSchedJSON struct {
+	Enabled     bool       `json:"enabled"`
+	Cron        string     `json:"cron"`
+	ScheduledAt *time.Time `json:"scheduledAt"`
+}
+
+// batteryStateString returns a camelCase string for the battery state.
+func batteryStateString(state powerinfo.BatteryState, chargeRate int) string {
+	switch state {
+	case powerinfo.Charging:
+		return "charging"
+	case powerinfo.Discharging:
+		if chargeRate != 0 {
+			return "discharging"
+		}
+		return "notCharging"
+	case powerinfo.Full:
+		return "full"
+	default:
+		return "notCharging"
+	}
+}
+
+func printStatusJSON(cmd *cobra.Command, data *statusData, cfg *config.File) error {
+	mode := cfg.ControlMagSafeLED()
+	upperLimit := cfg.UpperLimit()
+	enabled := upperLimit < 100
+
+	// When batt is disabled (limit=100%), lower limit equals upper limit
+	// because the battery is always allowed to charge freely.
+	lowerLimit := cfg.LowerLimit()
+	if !enabled {
+		lowerLimit = upperLimit
+	}
+
+	out := statusJSON{
+		Charging: statusChargingJSON{
+			AllowCharging: data.charging,
+			UseAdapter:    data.adapter,
+			PluggedIn:     data.pluggedIn,
+		},
+		Battery: statusBatteryJSON{
+			CurrentChargePercent: data.currentCharge,
+			State:                batteryStateString(data.batteryInfo.State, data.batteryInfo.ChargeRate),
+			TimeToLimitMinutes:   computeTimeToLimit(data, cfg),
+			FullCapacityMah:      data.batteryInfo.Design,
+			ChargeRateWatts:      math.Round(float64(data.batteryInfo.ChargeRate)/1e3*10) / 10,
+			VoltageVolts:         math.Round(data.batteryInfo.DesignVoltage*100) / 100,
+		},
+		Configuration: statusConfigJSON{
+			Enabled:                 enabled,
+			UpperLimitPercent:       upperLimit,
+			LowerLimitPercent:       lowerLimit,
+			PreventIdleSleep:        cfg.PreventIdleSleep(),
+			DisableChargingPreSleep: cfg.DisableChargingPreSleep(),
+			PreventSystemSleep:      cfg.PreventSystemSleep(),
+			AllowNonRootAccess:      cfg.AllowNonRootAccess(),
+			ControlMagSafeLed: statusMagSafeLedJSON{
+				Enabled: mode != config.ControlMagSafeModeDisabled,
+				Mode:    string(mode),
+			},
+		},
+	}
+
+	tr, err := apiClient.GetTelemetry(false, true)
+	if err == nil && tr.Calibration != nil {
+		cal := tr.Calibration
+
+		var startedAt *time.Time
+		if cal.Phase != calibration.PhaseIdle && !cal.StartedAt.IsZero() {
+			startedAt = &cal.StartedAt
+		}
+
+		cron := cfg.Cron()
+		sched := statusCalibrationSchedJSON{
+			Enabled: cron != "",
+			Cron:    cron,
+		}
+		if cron != "" && !cal.ScheduledAt.IsZero() {
+			sched.ScheduledAt = &cal.ScheduledAt
+		}
+
+		out.Calibration = &statusCalibrationJSON{
+			Phase:     string(cal.Phase),
+			StartedAt: startedAt,
+			Paused:    cal.Paused,
+			CanPause:  cal.CanPause,
+			CanCancel: cal.CanCancel,
+			Message:   cal.Message,
+			Schedule:  sched,
+		}
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/cmd/batt/status_json.go
+++ b/cmd/batt/status_json.go
@@ -13,11 +13,11 @@ import (
 )
 
 type statusJSON struct {
-	Charging      statusChargingJSON     `json:"charging"`
-	Battery       statusBatteryJSON      `json:"battery"`
-	Configuration statusConfigJSON       `json:"configuration"`
+	Charging      statusChargingJSON `json:"charging"`
+	Battery       statusBatteryJSON  `json:"battery"`
+	Configuration statusConfigJSON   `json:"configuration"`
 	// Calibration is omitted when telemetry data is unavailable (e.g. API error).
-	Calibration   *statusCalibrationJSON `json:"calibration,omitempty"`
+	Calibration *statusCalibrationJSON `json:"calibration,omitempty"`
 }
 
 type statusChargingJSON struct {


### PR DESCRIPTION
Hey @charlie0129! Following up on your suggestion in #120 — this adds a `--json` flag to `batt status` so scripts and tools can parse the output reliably. There are already integrations out there that would benefit from this, like the [Raycast Battery Optimizer extension](https://www.raycast.com/Qetesh/battery-optimizer), which currently has to [scrape the human-readable output](https://github.com/raycast/extensions/blob/361825fd7fe65766708330ea6a4722af57ff9983/extensions/battery-optimizer/src/utils/batteryTools.ts#L55-L89).

## What this does

`batt status --json` outputs a structured JSON representation of the same data shown by the human-readable format:

```json
{
  "charging": {
    "allowCharging": true,
    "useAdapter": true,
    "pluggedIn": true
  },
  "battery": {
    "currentChargePercent": 72,
    "state": "charging",
    "timeToLimitMinutes": 34,
    "fullCapacityMah": 5103,
    "chargeRateWatts": 28.5,
    "voltageVolts": 12.84
  },
  "configuration": {
    "enabled": true,
    "upperLimitPercent": 80,
    "lowerLimitPercent": 70,
    "preventIdleSleep": false,
    "disableChargingPreSleep": true,
    "preventSystemSleep": false,
    "allowNonRootAccess": true,
    "controlMagSafeLed": {
      "enabled": false,
      "mode": "disabled"
    }
  },
  "calibration": {
    "phase": "Idle",
    "startedAt": null,
    "paused": false,
    "canPause": false,
    "canCancel": false,
    "message": "",
    "schedule": {
      "enabled": true,
      "cron": "0 0 1 * *",
      "scheduledAt": "2026-03-01T00:00:00Z"
    }
  }
}
```

A few design notes:

- **Battery state** uses camelCase strings: `"charging"`, `"discharging"`, `"notCharging"`, `"full"`
- **`timeToLimitMinutes`** is `null` when not applicable (not charging, limit is 100%, or charge is already at/above limit)
- **`calibration`** is omitted entirely when telemetry data is unavailable
- **`lowerLimitPercent`** equals `upperLimitPercent` when batt is disabled (limit=100%), since in practice the battery is always allowed to charge freely

## Changes

- **`cmd/batt/status_json.go`** (new) — JSON struct types, `batteryStateString()`, and `printStatusJSON()`
- **`cmd/batt/status.go`** — extracted `computeTimeToLimit()` as a shared helper (was inlined), added `--json` flag wiring

The human-readable output is unchanged.

## How to test

```bash
# JSON output
batt status --json

# Pipe to jq
batt status --json | jq '.battery.state'

# Human-readable output still works as before
batt status
```

Let me know if you'd like any changes to the JSON schema or field naming!
