### PR TITLE
chore: update powerkit-go to v0.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charlie0129/gosmc v0.0.0-20250206014004-02656b3859e0
 	github.com/fatih/color v1.15.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/peterneutron/powerkit-go v0.3.3
+	github.com/peterneutron/powerkit-go v0.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/progrium/darwinkit v0.5.1-0.20240715194340-61b9e31a12fa
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
-github.com/peterneutron/powerkit-go v0.3.3 h1:hHjt9OqHpwRR7SHPmqz7FWK6+6g9TGinapWvUelIR6Q=
-github.com/peterneutron/powerkit-go v0.3.3/go.mod h1:Bqj3JNxrIavl/qPWlmpz72HZXiglCqnV9juBZBWqfJw=
+github.com/peterneutron/powerkit-go v0.9.4 h1:Z2fXoy/FIr0zoYpmkqyYeRyvnUVnmtCGt+TBxQnMiNU=
+github.com/peterneutron/powerkit-go v0.9.4/go.mod h1:Bqj3JNxrIavl/qPWlmpz72HZXiglCqnV9juBZBWqfJw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

Updates `github.com/peterneutron/powerkit-go` from `v0.3.3` to `v0.9.4`.

This keeps batt on the current powerkit-go release before temperature monitoring work such as #132 depends on `powerkit.GetSystemInfo(...).IOKit.Battery.Temperature`.

## Scope

This is intentionally dependency-only:

- updates `go.mod`
- updates `go.sum`
- does not change batt daemon, CLI, GUI, SMC, charging, MagSafe, or telemetry code paths

## Notes

`powerkit-go v0.9.4` includes the corrected smart battery temperature conversion for raw IOKit `Temperature` values, treating them as deci-Kelvin and exposing Celsius.

Current batt `master` does not expose battery temperature yet, so this PR is mostly preparation for temperature-related work and keeps the dependency current without changing batt behavior directly.

## Verification

```sh
GOWORK=off go test ./...
```

Passed locally.

Existing macOS `NSUserNotification` deprecation warnings from `pkg/gui` are unchanged.
