### PR TITLE
WIP: Add macOS 27 SMC keys

### DIFF
--- a/pkg/smc/adapter.go
+++ b/pkg/smc/adapter.go
@@ -23,6 +23,8 @@ func (c *AppleSMC) IsAdapterEnabled() (bool, error) {
 		key = AdapterKey2
 	case c.capabilities[AdapterKey3]: // Tahoe firmware versions.
 		key = AdapterKey3
+	case c.capabilities[AdapterKey4]: // macOS 27+ (Sequoia) firmware versions.
+		key = AdapterKey4
 	default:
 		return false, ErrNoAdapterCapability
 	}
@@ -34,7 +36,7 @@ func (c *AppleSMC) IsAdapterEnabled() (bool, error) {
 
 	ret = len(v.Bytes) == 1 && v.Bytes[0] == 0x0
 
-	logrus.Tracef("IsAdapterEnabled returned %t", ret)
+	logrus.Tracef("IsAdapterEnabled (key=%s) returned %t", key, ret)
 
 	return ret, nil
 }
@@ -50,6 +52,8 @@ func (c *AppleSMC) EnableAdapter() error {
 		return c.Write(AdapterKey2, []byte{0x0})
 	case c.capabilities[AdapterKey3]: // Tahoe firmware versions.
 		return c.Write(AdapterKey3, []byte{0x0})
+	case c.capabilities[AdapterKey4]: // macOS 27+ (Sequoia) firmware versions.
+		return c.Write(AdapterKey4, []byte{0x0})
 	default:
 		return ErrNoAdapterCapability
 	}
@@ -66,6 +70,8 @@ func (c *AppleSMC) DisableAdapter() error {
 		return c.Write(AdapterKey2, []byte{0x1})
 	case c.capabilities[AdapterKey3]: // Tahoe firmware versions.
 		return c.Write(AdapterKey3, []byte{0x8})
+	case c.capabilities[AdapterKey4]: // macOS 27+ (Sequoia) firmware versions.
+		return c.Write(AdapterKey4, []byte{0x1})
 	default:
 		return ErrNoAdapterCapability
 	}

--- a/pkg/smc/charging.go
+++ b/pkg/smc/charging.go
@@ -23,14 +23,16 @@ func (c *AppleSMC) IsChargingEnabled() (bool, error) {
 		return ret, nil
 	}
 
-	// Tahoe firmware versions.
-	v, err := c.Read(ChargingKey3)
+	// Tahoe / macOS 27+ firmware versions.
+	// Both use the same 4-byte format: all zeros means charging enabled.
+	chargingKey := c.getChargingKey()
+	v, err := c.Read(chargingKey)
 	if err != nil {
 		return false, err
 	}
 
 	ret := len(v.Bytes) == 4 && bytes.Equal(v.Bytes, []byte{0x00, 0x00, 0x00, 0x00})
-	logrus.Tracef("IsChargingEnabled returned %t", ret)
+	logrus.Tracef("IsChargingEnabled (key=%s) returned %t", chargingKey, ret)
 
 	return ret, nil
 }
@@ -38,7 +40,7 @@ func (c *AppleSMC) IsChargingEnabled() (bool, error) {
 func (c *AppleSMC) IsChargingControlCapable() bool {
 	logrus.Tracef("IsChargingControlCapable called")
 
-	for _, key := range []string{ChargingKey1, ChargingKey2, ChargingKey3} {
+	for _, key := range []string{ChargingKey1, ChargingKey2, ChargingKey3, ChargingKey4} {
 		if c.capabilities[key] {
 			logrus.Tracef("IsChargingControlCapable returned true for key %s", key)
 			return true
@@ -65,8 +67,11 @@ func (c *AppleSMC) EnableCharging() error {
 		return nil
 	}
 
-	// Tahoe firmware versions.
-	return c.Write(ChargingKey3, []byte{0x00, 0x00, 0x00, 0x00})
+	// Tahoe / macOS 27+ firmware versions.
+	// Both use the same 4-byte format: all zeros means charging enabled.
+	key := c.getChargingKey()
+	logrus.Tracef("EnableCharging writing to key %s", key)
+	return c.Write(key, []byte{0x00, 0x00, 0x00, 0x00})
 }
 
 // DisableCharging disables charging.
@@ -86,6 +91,19 @@ func (c *AppleSMC) DisableCharging() error {
 		return nil
 	}
 
-	// Tahoe firmware versions.
-	return c.Write(ChargingKey3, []byte{0x01, 0x00, 0x00, 0x00})
+	// Tahoe / macOS 27+ firmware versions.
+	// Both use the same 4-byte format: 0x01 in first byte means charging disabled.
+	key := c.getChargingKey()
+	logrus.Tracef("DisableCharging writing to key %s", key)
+	return c.Write(key, []byte{0x01, 0x00, 0x00, 0x00})
+}
+
+// getChargingKey returns the SMC key to use for charging control.
+// Priority: ChargingKey4 (macOS 27+) > ChargingKey3 (Tahoe).
+// Pre-Tahoe uses ChargingKey1+ChargingKey2 and is handled separately.
+func (c *AppleSMC) getChargingKey() string {
+	if c.capabilities[ChargingKey4] {
+		return ChargingKey4
+	}
+	return ChargingKey3
 }

--- a/pkg/smc/consts_amd64.go
+++ b/pkg/smc/consts_amd64.go
@@ -9,6 +9,44 @@ const (
 	ACPowerKey       = "AC-W" // Not verified yet.
 	ChargingKey1     = "CH0B" // Not verified yet.
 	ChargingKey2     = "CH0C" // Not verified yet.
+	ChargingKey3     = "CHTE" // Not verified yet.
+	ChargingKey4     = "CHTC" // Not verified yet, macOS 27+ (Sequoia).
 	AdapterKey       = "CH0K"
+	AdapterKey1      = "CH0I" // Not verified yet.
+	AdapterKey2      = "CH0J" // Not verified yet.
+	AdapterKey3      = "CHIE" // Not verified yet.
+	AdapterKey4      = "CHIB" // Not verified yet, macOS 27+ (Sequoia).
+	AdapterKey5      = "CHIC" // Not verified yet, macOS 27+ (Sequoia).
 	BatteryChargeKey = "BBIF"
+
+	// Power Telemetry Keys
+	DCInCurrentKey    = "ID0R"
+	DCInVoltageKey    = "VD0R"
+	DCInPowerKey      = "PDTR"
+	BatteryCurrentKey = "B0AC"
+	BatteryVoltageKey = "B0AV"
+	BatteryPowerKey   = "PPBR"
 )
+
+var allKeys = []string{
+	MagSafeLedKey,
+	ACPowerKey,
+	ChargingKey1,
+	ChargingKey2,
+	ChargingKey3,
+	ChargingKey4,
+	AdapterKey,
+	AdapterKey1,
+	AdapterKey2,
+	AdapterKey3,
+	AdapterKey4,
+	AdapterKey5,
+	BatteryChargeKey,
+	DCInCurrentKey,
+	DCInVoltageKey,
+	DCInPowerKey,
+	BatteryCurrentKey,
+	BatteryVoltageKey,
+	BatteryPowerKey,
+}
+

--- a/pkg/smc/consts_arm64.go
+++ b/pkg/smc/consts_arm64.go
@@ -8,10 +8,16 @@ const (
 	ChargingKey2  = "CH0C"
 	// ChargingKey3 is used for Tahoe firmware versions.
 	ChargingKey3 = "CHTE"
+	// ChargingKey4 is used for macOS 27+ (Sequoia) firmware versions.
+	ChargingKey4 = "CHTC"
 	AdapterKey1  = "CH0I"
 	AdapterKey2  = "CH0J"
 	// AdapterKey3 is used for Tahoe firmware versions.
-	AdapterKey3      = "CHIE"
+	AdapterKey3 = "CHIE"
+	// AdapterKey4 is used for macOS 27+ (Sequoia) firmware versions.
+	AdapterKey4 = "CHIB"
+	// AdapterKey5 is used for macOS 27+ (Sequoia) firmware versions.
+	AdapterKey5      = "CHIC"
 	BatteryChargeKey = "BUIC"
 
 	// Power Telemetry Keys
@@ -29,9 +35,12 @@ var allKeys = []string{
 	ChargingKey1,
 	ChargingKey2,
 	ChargingKey3,
+	ChargingKey4,
 	AdapterKey1,
 	AdapterKey2,
 	AdapterKey3,
+	AdapterKey4,
+	AdapterKey5,
 	BatteryChargeKey,
 	DCInCurrentKey,
 	DCInVoltageKey,


### PR DESCRIPTION
First attempt at fixing macOS 27 support.

This currently makes `batt` start again and report the status, turn the LED at the correct moment, **but, it does not stop the charging.**

@charlie0129 Maybe this is helpful.
I will continue working on this in a few days.

`batt status` output:
```
Charging status:
  Allow charging: ✔ (refreshes can take up to 2 minutes)
    Your Mac will charge.
  Use power adapter: ✔
    Your Mac will use power from the wall (to operate or charge), if it is plugged in.

Battery status:
  Current charge: 72%
  State: charging
  Full capacity: 0 mAh
  Charge rate: +58.2 W
  Voltage: 12.42 V

Battery configuration:
  Upper limit: 50%
  Lower limit: 48%
  Prevent idle-sleep when charging: ✔
  Disable charging before sleep if charge limit is enabled: ✔
  Prevent system-sleep when charging: ✘
  Allow non-root users to access the daemon: ✔
  Control MagSafe LED: ✔

Calibration status:
  Phase: Idle
  Schedule: disabled
  ```