### PR TITLE
feat: macos 27 firmware support and capability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ However, if you are nerdy and want to dive into the details, it does have some a
 
 - Control MagSafe LED (if present) according to charge status. [Docs](#control-magsafe-led)
 - Cut power from the wall (even if the adapter is physically plugged in) to use battery power. [Docs](#enabledisable-power-adapter)
-- On legacy firmware, it solves common sleep-related issues when controlling charging. [Docs1](#preventing-idle-sleep) [Docs2](#disabling-charging-before-sleep)
+- On firmware < `20xxx`, it solves common sleep-related issues when controlling charging. [Docs1](#preventing-idle-sleep) [Docs2](#disabling-charging-before-sleep)
 - Calibrate battery automatically. [Docs](#auto-calibration-experimental)
 
 ## How is it different from XXX?
 
 **It is free and opensource**. It even comes with some features (like idle sleep preventions and pre-sleep stop charging) that are only available in paid counterparts. It comes with no ads, no tracking, no telemetry, no analytics, no bullshit. It is open source, so you can read the code and verify that it does what it says it does.
 
-**It is simple but well-thought.** It only does charge limiting and does it well. On legacy firmware, `batt` handles sleep edge cases that can otherwise let a MacBook charge to 100%. On newer firmware, it delegates the range to Apple SMC so enforcement continues during sleep. Other features are intentionally limited to keep it simple. If you encounter a problem or want an additional feature, please raise an issue.
+**It is simple but well-thought.** It only does charge limiting and does it well. On firmware < `20xxx`, `batt` handles sleep edge cases that can otherwise let a MacBook charge to 100%. On newer firmware, it delegates the range to Apple SMC so enforcement continues during sleep. Other features are intentionally limited to keep it simple. If you encounter a problem or want an additional feature, please raise an issue.
 
 **It is light-weight.** No electron GUIs hogging your system resources like some other tools. You can use batt on the command-line, or use the native macOS menubar app if you prefer a GUI. The GUI is written using native macOS APIs, so it is light-weight and fast.
 
@@ -51,16 +51,16 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 
 ## Compatibility Matrix
 
-| Firmware Version        | Typical macOS release | GUI  | CLI (Prebuilt) | CLI (Build from Source) | Note                                      |
-| ----------------------- | ---------------------- | ---- | -------------- | ----------------------- | ----------------------------------------- |
-| `6723.x.x`              | Older                  | ❌    | ❌              | ⚠️                       |                                           |
-| `7429.x.x` / `7459.x.x` | Older                  | ❌    | ⚠️              | ✅                       |                                           |
-| `8419.x.x` / `8422.x.x` | Older                  | ⚠️    | ⚠️              | ✅                       |                                           |
-| `101xx.x.x`             | macOS 14               | ⚠️    | ⚠️              | ✅                       |                                           |
-| `118xx.x.x`             | macOS 15               | ✅    | ✅              | ✅                       |                                           |
-| `138xx.x.x` / `18xxx.x.x` | macOS 26 Tahoe      | ✅    | ✅              | ✅                       |                                           |
-| `20xxx.x.x`             | macOS 27 Golden Gate   | ✅    | ✅              | ✅                       | Firmware-managed limits; see below        |
-| Other                   | Unknown                | ❓    | ❓              | ❓                       |                                           |
+| Firmware Version          | First macOS release  | GUI | CLI (Prebuilt) | CLI (Build from Source) | Note                               |
+| ------------------------- | -------------------- | --- | -------------- | ----------------------- | ---------------------------------- |
+| `6723.x.x`                | macOS 11 Big Sur     | ❌   | ❌              | ⚠️                       |                                    |
+| `7429.x.x` / `7459.x.x`   | macOS 12 Monterey    | ❌   | ⚠️              | ✅                       |                                    |
+| `8419.x.x` / `8422.x.x`   | macOS 13 Ventura     | ⚠️   | ⚠️              | ✅                       |                                    |
+| `101xx.x.x`               | macOS 14 Sonoma      | ⚠️   | ⚠️              | ✅                       |                                    |
+| `118xx.x.x`               | macOS 15 Sequoia     | ✅   | ✅              | ✅                       |                                    |
+| `138xx.x.x` / `18xxx.x.x` | macOS 26 Tahoe       | ✅   | ✅              | ✅                       |                                    |
+| `20xxx.x.x`               | macOS 27 Golden Gate | ✅   | ✅              | ✅                       | Firmware-managed limits; see below |
+| Other                     | Unknown              | ❓   | ❓              | ❓                       |                                    |
 
 - ❌: Unsupported
 - ✅: Supported
@@ -68,7 +68,7 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 - ❓: Unknown, please raise an issue if you have tested it.
 
 > [!NOTE]
-> Firmware version is different from macOS version. You can check your firmware version by running `system_profiler SPHardwareDataType | grep -i firmware` in Terminal.
+> Firmware version is different from macOS version. Old macOS versions may have newer firmware (macOS 15 but running firmware `138xx.x.x`). You can check your firmware version by running `system_profiler SPHardwareDataType | grep -i firmware` in Terminal.
 
 `batt` does not branch on the reported macOS or firmware version. It probes usable, non-empty SMC keys at runtime: `CH0B` + `CH0C` or `CHTE` select legacy direct charging control, while `bfF0` selects firmware-managed limits. Zero-sized placeholder keys are ignored. This also handles an older macOS installation receiving newer firmware.
 
@@ -80,8 +80,8 @@ This mode has several intentional differences and current limitations:
 
 - If the battery is above the upper limit, firmware can stop drawing wall power and use the battery to run the Mac. Unlike legacy control, the percentage may therefore fall.
 - MagSafe LED control is unavailable because `batt` no longer owns or reliably knows the charging-enabled state.
-- Adapter enable/disable (including GUI “Force Discharge”) is unavailable unless a known adapter-control SMC key is present. No such key is currently known on 20xxx firmware.
-- Auto calibration and calibration scheduling are unavailable without legacy direct charging and adapter controls.
+- Adapter enable/disable (including GUI “Force Discharge”) is available when a known adapter-control SMC key is present, including on tested 20xxx firmware.
+- Auto calibration and calibration scheduling are available when adapter control is supported. During the full-charge phase, `batt` temporarily deactivates the firmware limit, then restores the configured range afterward.
 - Legacy sleep options are unavailable and unnecessary. Incompatible values left in the configuration after an upgrade are disabled by the daemon.
 
 The daemon reports these capabilities to current CLI and GUI clients. Older daemons that do not provide detailed compatibility data retain the previous permissive client behavior.
@@ -176,7 +176,7 @@ To customize charge limit, see `batt limit`. For example,to set the limit to 80%
 
 Cut or restore power from the wall. This has the same effect as unplugging/plugging the power adapter, even if the adapter is physically plugged in.
 
-This command is available only when the daemon detects a known adapter-control SMC key. It is currently unavailable on macOS 27 / 20xxx firmware.
+This command is available only when the daemon detects a known adapter-control SMC key. It is supported on tested macOS 27 / 20xxx firmware, but capability detection remains authoritative because keys can vary by model and firmware.
 
 This is useful when you want to use your battery to lower the battery charge, but you don't want to unplug the power adapter.
 
@@ -203,7 +203,7 @@ These advanced features are not for most users. Using the default setting for th
 
 Automatically performs a full charging cycle to help calibrate reported battery percentage.
 
-This workflow requires legacy direct charging control and adapter control. It is unavailable on macOS 27 / 20xxx firmware.
+This workflow requires adapter control. On macOS 27 / 20xxx firmware, `batt` uses adapter control for discharge phases and temporarily deactivates the firmware limit while charging to full.
 
 Phases: `Idle → DischargeToThreshold → ChargeToFull → HoldAfterFull → DischargeAfterHold → RestoreAndFinish → Idle`.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Quick link to [installation guide](#installation).
 
 - Limit battery charge, with a lower and upper bound, like ThinkPads. [Docs](#limit-battery-charge)
 
-However, if you are nerdy and want to dive into the details, it does have some advanced features for the computer nerds out there :). These are shown only when the current Mac's SMC keys support them.
+However, if you are nerdy and want to dive into the details, it does have some advanced features for power users. These are shown only when the current Mac's SMC keys support them.
 
 - Control MagSafe LED (if present) according to charge status. [Docs](#control-magsafe-led)
 - Cut power from the wall (even if the adapter is physically plugged in) to use battery power. [Docs](#enabledisable-power-adapter)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Flow:
 4. After hold, charging is disabled again and the battery is allowed to naturally discharge back down to the original upper limit snapshot.
 5. Restore original upper/lower limits and adapter/charging states and return to Idle.
 
+`batt` prevents idle system sleep for the entire calibration session, including while paused, and releases the assertion on completion, cancellation, or error. macOS can still force sleep when you close the lid or explicitly choose Sleep, so keep the lid open during calibration.
+
 You can start, pause, resume, cancel via the GUI (Advanced → Auto Calibration) or CLI (`batt calibration start|pause|resume|cancel|status`) or HTTP API. Cancel restores original settings immediately.
 
 To change the discharge threshold (defaults to 15%), run `batt calibration discharge-threshold <percentage>`.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 
 ## Compatibility Matrix
 
+Check your firmware version by running `system_profiler SPHardwareDataType | grep -i firmware` in Terminal. Do NOT rely on macOS version.
+
 | Firmware Version          | First macOS release  | GUI | CLI (Prebuilt) | CLI (Build from Source) | Note                               |
 | ------------------------- | -------------------- | --- | -------------- | ----------------------- | ---------------------------------- |
 | `6723.x.x`                | macOS 11 Big Sur     | ❌   | ❌              | ⚠️                       |                                    |
@@ -68,7 +70,7 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 - ❓: Unknown, please raise an issue if you have tested it.
 
 > [!NOTE]
-> Firmware version is different from macOS version. Old macOS versions may have newer firmware (macOS 15 but running firmware `138xx.x.x`). You can check your firmware version by running `system_profiler SPHardwareDataType | grep -i firmware` in Terminal.
+> Firmware version is different from macOS version. Old macOS versions may have newer firmware, e.g. macOS 15 with firmware `138xx.x.x` (macOS Tahoe version).
 
 `batt` does not branch on the reported macOS or firmware version. It probes usable, non-empty SMC keys at runtime: `CH0B` + `CH0C` or `CHTE` select legacy direct charging control, while `bfF0` selects firmware-managed limits. Zero-sized placeholder keys are ignored. This also handles an older macOS installation receiving newer firmware.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Check your firmware version by running `system_profiler SPHardwareDataType | gre
 > [!NOTE]
 > Firmware version is different from macOS version. Old macOS versions may have newer firmware, e.g. macOS 15 with firmware `138xx.x.x` (macOS Tahoe version).
 
-`batt` does not branch on the reported macOS or firmware version. It probes usable, non-empty SMC keys at runtime: `CH0B` + `CH0C` or `CHTE` select legacy direct charging control, while `bfF0` selects firmware-managed limits. Zero-sized placeholder keys are ignored. This also handles an older macOS installation receiving newer firmware.
+`batt` does not branch on the reported macOS or firmware version. It probes usable SMC keys at runtime (mainly tied to the firmware version, not the macOS version). This also handles an older macOS installation receiving newer firmware.
+
+If you want to know which MacBooks I personally developed it on, I am using it on all my personal MacBooks every single day, including MacBook Air M1 2020 (A2337), MacBook Air M2 2022 (A2681), MacBook Pro 14' M1 Pro 2021 (A2442), MacBook Pro 16' M1 Max 2021 (A2485).
+
+If you encounter any incompatibility, please raise an issue with your MacBook model, firmware version, batt version, macOS version, and batt logs (`/tmp/batt.log`).
 
 ### macOS 27 / 20xxx firmware behavior
 
@@ -82,15 +86,9 @@ This mode has several intentional differences and current limitations:
 
 - If the battery is above the upper limit, firmware can stop drawing wall power and use the battery to run the Mac. Unlike legacy control, the percentage may therefore fall.
 - MagSafe LED control is unavailable because `batt` no longer owns or reliably knows the charging-enabled state.
-- Adapter enable/disable (including GUI “Force Discharge”) is available when a known adapter-control SMC key is present, including on tested 20xxx firmware.
-- Auto calibration and calibration scheduling are available when adapter control is supported. During the full-charge phase, `batt` temporarily deactivates the firmware limit, then restores the configured range afterward.
 - Legacy sleep options are unavailable and unnecessary. Incompatible values left in the configuration after an upgrade are disabled by the daemon.
 
 The daemon reports these capabilities to current CLI and GUI clients. Older daemons that do not provide detailed compatibility data retain the previous permissive client behavior.
-
-If you want to know which MacBooks I personally developed it on, I am using it on all my personal MacBooks every single day, including MacBook Air M1 2020 (A2337), MacBook Air M2 2022 (A2681), MacBook Pro 14' M1 Pro 2021 (A2442), MacBook Pro 16' M1 Max 2021 (A2485).
-
-If you encounter any incompatibility, please raise an issue with your MacBook model and macOS version.
 
 ## Installation (GUI Version)
 
@@ -152,7 +150,7 @@ You can choose either one. Please do not use both at the same time to avoid conf
 - Test if it works by running `sudo batt status`. If you see your battery status, you are good to go!
 - Time to customize. By default `batt` will set a charge limit to 60%. For example, to set the charge limit to 80%, run `sudo batt limit 80`.
 - As said before, it is _highly_ recommended to disable macOS's optimized charging when using `batt`. To do so, open `System Settings` -> `Battery` -> `Battery Health` -> `i` -> Turn OFF `Optimized Battery Charging`. Built-in charge limit also need to be disabled if you are on macOS 26.4 or later.
-- If your current charge is above the limit, behavior depends on the detected backend. Legacy firmware stops charging and keeps running from the wall, so the percentage stays steady. macOS 27-era firmware may run from the battery until it falls back into the configured range.
+- If your current charge is above the limit, behavior depends on the detected backend. Firmwares < `20xxx` stops charging and keeps running from the wall, so the percentage stays steady. `20xxx` firmware may run from the battery until it falls back into the configured range.
 - You can refer to [Usage](#usage) for additional configurations. Don't know what a command does? Run `batt help` to see all available commands. To see help for a specific command, run `batt help <command>`.
 - To disable the charge limit, run `batt disable` or `batt limit 100`.
 - [How to uninstall?](#how-to-uninstall) [How to upgrade?](#how-to-upgrade)
@@ -178,8 +176,6 @@ To customize charge limit, see `batt limit`. For example,to set the limit to 80%
 
 Cut or restore power from the wall. This has the same effect as unplugging/plugging the power adapter, even if the adapter is physically plugged in.
 
-This command is available only when the daemon detects a known adapter-control SMC key. It is supported on tested macOS 27 / 20xxx firmware, but capability detection remains authoritative because keys can vary by model and firmware.
-
 This is useful when you want to use your battery to lower the battery charge, but you don't want to unplug the power adapter.
 
 NOTE: if you are using Clamshell mode (using a Mac laptop with an external monitor and the lid closed), *cutting power will cause your Mac to go to sleep*. This is a limitation of macOS. There are ways to prevent this, but it is not recommended for most users.
@@ -204,8 +200,6 @@ These advanced features are not for most users. Using the default setting for th
 > Thanks @brookqin for implementing the initial version of this feature.
 
 Automatically performs a full charging cycle to help calibrate reported battery percentage.
-
-This workflow requires adapter control. On macOS 27 / 20xxx firmware, `batt` uses adapter control for discharge phases and temporarily deactivates the firmware limit while charging to full.
 
 Phases: `Idle → DischargeToThreshold → ChargeToFull → HoldAfterFull → DischargeAfterHold → RestoreAndFinish → Idle`.
 
@@ -244,7 +238,7 @@ Before a scheduled calibration actually begins, `batt` checks that the Mac is pl
 ### Preventing idle sleep
 
 > [!NOTE]
-> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable and unnecessary with macOS 27-era `bfF0` firmware, where the firmware enforces limits during sleep.
+> This is a legacy-control option for older firmware < `20xxx`. It is unavailable and unnecessary with `20xxx` firmware, where the firmware enforces limits during sleep.
 
 Set whether to prevent idle sleep during a charging session.
 
@@ -259,7 +253,7 @@ To enable this feature, run `sudo batt prevent-idle-sleep enable`. To disable, r
 ### Disabling charging before sleep
 
 > [!NOTE]
-> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable and unnecessary with macOS 27-era `bfF0` firmware, where the firmware enforces limits during sleep.
+> This is a legacy-control option for older firmware < `20xxx`. It is unavailable and unnecessary with `20xxx` firmware, where the firmware enforces limits during sleep.
 
 Set whether to disable charging before sleep if charge limit is enabled.
 
@@ -270,7 +264,7 @@ To enable this feature, run `sudo batt disable-charging-pre-sleep enable`. To di
 ### Prevent system sleep
 
 > [!NOTE]
-> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable with macOS 27-era `bfF0` firmware.
+> This is a legacy-control option for older firmware < `20xxx`. It is unavailable with `20xxx` firmware.
 
 Set whether to prevent system sleep during a charging session (experimental).
 
@@ -439,7 +433,7 @@ Probably not. `batt` was made Apple-Silicon-only after some early development. I
 ### Why does my MacBook stop charging after I close the lid?
 
 > [!NOTE]
-> This FAQ applies only to older firmware using legacy direct charging control. On macOS 27-era `bfF0` firmware, the charge limit persists through sleep and `batt` does not disable charging before sleep.
+> This FAQ applies only to older firmware < `20xxx` using direct charging control. On `20xxx` firmware, the charge limit persists through sleep and `batt` does not disable charging before sleep.
 
 TL,DR; This is intended, and is the default behavior. It is described [here](#disabling-charging-before-sleep). You can turn this feature off by running `sudo batt disable-charging-pre-sleep disable` (not recommended, keep reading).
 
@@ -478,7 +472,7 @@ If you want to prevent this, you need to disable sleep globally using pmset, or 
 ### My Mac does not start charging after waking up from sleep
 
 > [!NOTE]
-> This FAQ applies only to older firmware using legacy direct charging control. macOS 27-era `bfF0` firmware has no `batt` post-wake delay.
+> This FAQ applies only to older firmware < `20xxx` using legacy direct charging control. `20xxx` firmware has no `batt` post-wake delay.
 
 This is expected. batt will prevent your Mac from charging temporarily if your Mac has just woken up from sleep. This is to prevent overcharging during sleep. Your Mac will start charging soon (at most 2 minutes).
 
@@ -487,7 +481,7 @@ If you absolutely need to charge your Mac _immediately_ after waking up from sle
 ### Why does my Mac starts charging after entering sleep?
 
 > [!NOTE]
-> This FAQ applies only to older firmware using legacy direct charging control. On macOS 27-era `bfF0` firmware, Apple firmware continues enforcing the configured range during sleep.
+> This FAQ applies only to older firmware < `20xxx` using legacy direct charging control. `20xxx` firmware continues enforcing the configured range during sleep.
 
 If you are using the default batt settings (i.e., `prevent-idle-sleep` and `disable-charging-pre-sleep` are both enabled), this should not happen.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!TIP]
-> Feb 17, 2026 UPDATE: Finally, after more than 5 years, macOS 26.4 and later supports charge limiting natively (adjustable from 80% to 100%), so **`batt` is not needed if you are using macOS 26.4 or later**. However, `batt` won't go anywhere so if you are on an older version of macOS or you want to set a charge limit lower than 80%, you can still use `batt`.
+> Feb 17, 2026 UPDATE: Finally, after more than 5 years, macOS 26.4 and later supports charge limiting natively (adjustable from 80% to 100%), so **`batt` is not needed if the built-in range meets your needs**. `batt` remains useful on older releases and when you want a limit below 80%. On macOS 27-era firmware, `batt` programs the firmware's charge-limit facility directly.
 
 Note: Use table of contents of quickly navigate to the section you want, e.g., `Installation`. 👆↗
 
@@ -16,7 +16,9 @@ Note: Use table of contents of quickly navigate to the section you want, e.g., `
 
 Previously, before optimized battery charging is introduced, MacBooks are known to suffer from battery swelling when they are kept at 100% all the time, especially the 2015s. Even with optimized battery charging, the effect is not optimal (described [below](#but-macos-have-similar-features-built-in-is-it)).
 
-`batt` can effectively alleviate this problem by limiting the battery charge level. It can be used to set a maximum charge level. For example, you can set it to 80%, and it will stop charging when the battery reaches 80%. Once it reaches the predefined level, your computer will use power from the wall _only_, leaving no strain on your battery.
+`batt` can effectively alleviate this problem by limiting the battery charge level. It can be used to set a maximum charge level. For example, you can set it to 80%, and it will stop charging when the battery reaches 80%.
+
+On older firmware, the computer then runs from wall power and the battery percentage remains steady. On macOS 27-era firmware, Apple changed the mechanism: the firmware may run the Mac from the battery when it is above the limit, so the percentage can drop until it returns to the configured range.
 
 Quick link to [installation guide](#installation).
 
@@ -26,18 +28,18 @@ Quick link to [installation guide](#installation).
 
 - Limit battery charge, with a lower and upper bound, like ThinkPads. [Docs](#limit-battery-charge)
 
-However, if you are nerdy and want to dive into the details, it does have some advanced features for the computer nerds out there :)
+However, if you are nerdy and want to dive into the details, it does have some advanced features for the computer nerds out there :). These are shown only when the current Mac's SMC keys support them.
 
 - Control MagSafe LED (if present) according to charge status. [Docs](#control-magsafe-led)
 - Cut power from the wall (even if the adapter is physically plugged in) to use battery power. [Docs](#enabledisable-power-adapter)
-- It solves common sleep-related issues when controlling charging. [Docs1](#preventing-idle-sleep) [Docs2](#disabling-charging-before-sleep)
+- On legacy firmware, it solves common sleep-related issues when controlling charging. [Docs1](#preventing-idle-sleep) [Docs2](#disabling-charging-before-sleep)
 - Calibrate battery automatically. [Docs](#auto-calibration-experimental)
 
 ## How is it different from XXX?
 
 **It is free and opensource**. It even comes with some features (like idle sleep preventions and pre-sleep stop charging) that are only available in paid counterparts. It comes with no ads, no tracking, no telemetry, no analytics, no bullshit. It is open source, so you can read the code and verify that it does what it says it does.
 
-**It is simple but well-thought.** It only does charge limiting and does it well. For example, when using other free/unpaid tools, your MacBook will sometimes charge to 100% during sleep even if you set the limit to, like, 60%. `batt` have taken these edge cases into consideration and will behave as intended (in case you do encounter problems, please raise an issue so that we can solve it). Other features is intentionally limited to keep it simple. If you want some additional features, feel free to raise an issue, then we can discuss.
+**It is simple but well-thought.** It only does charge limiting and does it well. On legacy firmware, `batt` handles sleep edge cases that can otherwise let a MacBook charge to 100%. On newer firmware, it delegates the range to Apple SMC so enforcement continues during sleep. Other features are intentionally limited to keep it simple. If you encounter a problem or want an additional feature, please raise an issue.
 
 **It is light-weight.** No electron GUIs hogging your system resources like some other tools. You can use batt on the command-line, or use the native macOS menubar app if you prefer a GUI. The GUI is written using native macOS APIs, so it is light-weight and fast.
 
@@ -49,17 +51,16 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 
 ## Compatibility Matrix
 
-| Firmware Version        | GUI  | CLI (Prebuilt) | CLI (Build from Source) | Note                             |
-| ----------------------- | ---- | -------------- | ----------------------- | -------------------------------- |
-| `6723.x.x`              | ❌    | ❌              | ⚠️                       |                                  |
-| `7429.x.x` / `7459.x.x` | ❌    | ⚠️              | ✅                       |                                  |
-| `8419.x.x` / `8422.x.x` | ⚠️    | ⚠️              | ✅                       |                                  |
-| `10151.x.x`             | ⚠️    | ⚠️              | ✅                       |                                  |
-| `11881.x.x`             | ✅    | ✅              | ✅                       |                                  |
-| `13822.x.x`             | ✅    | ✅              | ✅                       |                                  |
-| `18000.x.x`             | ✅    | ✅              | ✅                       |                                  |
-| `20xxx.x.x`             | ❌    | ❌              | ❌                       | Wait for future versions of batt |
-| Other                   | ❓    | ❓              | ❓                       |                                  |
+| Firmware Version        | Typical macOS release | GUI  | CLI (Prebuilt) | CLI (Build from Source) | Note                                      |
+| ----------------------- | ---------------------- | ---- | -------------- | ----------------------- | ----------------------------------------- |
+| `6723.x.x`              | Older                  | ❌    | ❌              | ⚠️                       |                                           |
+| `7429.x.x` / `7459.x.x` | Older                  | ❌    | ⚠️              | ✅                       |                                           |
+| `8419.x.x` / `8422.x.x` | Older                  | ⚠️    | ⚠️              | ✅                       |                                           |
+| `101xx.x.x`             | macOS 14               | ⚠️    | ⚠️              | ✅                       |                                           |
+| `118xx.x.x`             | macOS 15               | ✅    | ✅              | ✅                       |                                           |
+| `138xx.x.x` / `18xxx.x.x` | macOS 26 Tahoe      | ✅    | ✅              | ✅                       |                                           |
+| `20xxx.x.x`             | macOS 27 Golden Gate   | ✅    | ✅              | ✅                       | Firmware-managed limits; see below        |
+| Other                   | Unknown                | ❓    | ❓              | ❓                       |                                           |
 
 - ❌: Unsupported
 - ✅: Supported
@@ -68,6 +69,22 @@ Yes, macOS have optimized battery charging. It will try to find out your chargin
 
 > [!NOTE]
 > Firmware version is different from macOS version. You can check your firmware version by running `system_profiler SPHardwareDataType | grep -i firmware` in Terminal.
+
+`batt` does not branch on the reported macOS or firmware version. It probes usable, non-empty SMC keys at runtime: `CH0B` + `CH0C` or `CHTE` select legacy direct charging control, while `bfF0` selects firmware-managed limits. Zero-sized placeholder keys are ignored. This also handles an older macOS installation receiving newer firmware.
+
+### macOS 27 / 20xxx firmware behavior
+
+On firmware exposing `bfF0`, `batt` writes the upper and lower percentages to `bfD0` and `bfE0`, activates the limit, and periodically verifies that all three values are still correct. Apple firmware then decides when charging starts and stops. The limit continues to work while macOS and the `batt` daemon are asleep, so `batt` does not register sleep notifications or run pre-sleep/post-wake charging hooks in this mode.
+
+This mode has several intentional differences and current limitations:
+
+- If the battery is above the upper limit, firmware can stop drawing wall power and use the battery to run the Mac. Unlike legacy control, the percentage may therefore fall.
+- MagSafe LED control is unavailable because `batt` no longer owns or reliably knows the charging-enabled state.
+- Adapter enable/disable (including GUI “Force Discharge”) is unavailable unless a known adapter-control SMC key is present. No such key is currently known on 20xxx firmware.
+- Auto calibration and calibration scheduling are unavailable without legacy direct charging and adapter controls.
+- Legacy sleep options are unavailable and unnecessary. Incompatible values left in the configuration after an upgrade are disabled by the daemon.
+
+The daemon reports these capabilities to current CLI and GUI clients. Older daemons that do not provide detailed compatibility data retain the previous permissive client behavior.
 
 If you want to know which MacBooks I personally developed it on, I am using it on all my personal MacBooks every single day, including MacBook Air M1 2020 (A2337), MacBook Air M2 2022 (A2681), MacBook Pro 14' M1 Pro 2021 (A2442), MacBook Pro 16' M1 Max 2021 (A2485).
 
@@ -133,7 +150,7 @@ You can choose either one. Please do not use both at the same time to avoid conf
 - Test if it works by running `sudo batt status`. If you see your battery status, you are good to go!
 - Time to customize. By default `batt` will set a charge limit to 60%. For example, to set the charge limit to 80%, run `sudo batt limit 80`.
 - As said before, it is _highly_ recommended to disable macOS's optimized charging when using `batt`. To do so, open `System Settings` -> `Battery` -> `Battery Health` -> `i` -> Turn OFF `Optimized Battery Charging`. Built-in charge limit also need to be disabled if you are on macOS 26.4 or later.
-- If your current charge is above the limit, your computer will just stop charging and use power from the wall. It will stay at your current charge level, which is by design. You can use your battery until it is below the limit to see the effects.
+- If your current charge is above the limit, behavior depends on the detected backend. Legacy firmware stops charging and keeps running from the wall, so the percentage stays steady. macOS 27-era firmware may run from the battery until it falls back into the configured range.
 - You can refer to [Usage](#usage) for additional configurations. Don't know what a command does? Run `batt help` to see all available commands. To see help for a specific command, run `batt help <command>`.
 - To disable the charge limit, run `batt disable` or `batt limit 100`.
 - [How to uninstall?](#how-to-uninstall) [How to upgrade?](#how-to-upgrade)
@@ -159,6 +176,8 @@ To customize charge limit, see `batt limit`. For example,to set the limit to 80%
 
 Cut or restore power from the wall. This has the same effect as unplugging/plugging the power adapter, even if the adapter is physically plugged in.
 
+This command is available only when the daemon detects a known adapter-control SMC key. It is currently unavailable on macOS 27 / 20xxx firmware.
+
 This is useful when you want to use your battery to lower the battery charge, but you don't want to unplug the power adapter.
 
 NOTE: if you are using Clamshell mode (using a Mac laptop with an external monitor and the lid closed), *cutting power will cause your Mac to go to sleep*. This is a limitation of macOS. There are ways to prevent this, but it is not recommended for most users.
@@ -183,6 +202,8 @@ These advanced features are not for most users. Using the default setting for th
 > Thanks @brookqin for implementing the initial version of this feature.
 
 Automatically performs a full charging cycle to help calibrate reported battery percentage.
+
+This workflow requires legacy direct charging control and adapter control. It is unavailable on macOS 27 / 20xxx firmware.
 
 Phases: `Idle → DischargeToThreshold → ChargeToFull → HoldAfterFull → DischargeAfterHold → RestoreAndFinish → Idle`.
 
@@ -220,6 +241,9 @@ Before a scheduled calibration actually begins, `batt` checks that the Mac is pl
 
 ### Preventing idle sleep
 
+> [!NOTE]
+> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable and unnecessary with macOS 27-era `bfF0` firmware, where the firmware enforces limits during sleep.
+
 Set whether to prevent idle sleep during a charging session.
 
 Due to macOS limitations, `batt` will be paused when your computer goes to sleep. As a result, when you are in a charging session and your computer goes to sleep, there is no way for batt to stop charging (since batt is paused by macOS) and the battery will charge to 100%. This option, together with disable-charging-pre-sleep, will prevent this from happening.
@@ -232,6 +256,9 @@ To enable this feature, run `sudo batt prevent-idle-sleep enable`. To disable, r
 
 ### Disabling charging before sleep
 
+> [!NOTE]
+> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable and unnecessary with macOS 27-era `bfF0` firmware, where the firmware enforces limits during sleep.
+
 Set whether to disable charging before sleep if charge limit is enabled.
 
 As described in [Preventing idle sleep](#preventing-idle-sleep), batt will be paused by macOS when your computer goes to sleep, and there is no way for batt to continue controlling battery charging. This option will disable charging just before sleep, so your computer will not overcharge during sleep, even if the battery charge is below the limit.
@@ -239,6 +266,9 @@ As described in [Preventing idle sleep](#preventing-idle-sleep), batt will be pa
 To enable this feature, run `sudo batt disable-charging-pre-sleep enable`. To disable, run `sudo batt disable-charging-pre-sleep disable`.
 
 ### Prevent system sleep
+
+> [!NOTE]
+> This is a legacy-control option for older firmware (`CH0B` + `CH0C` or `CHTE`). It is unavailable with macOS 27-era `bfF0` firmware.
 
 Set whether to prevent system sleep during a charging session (experimental).
 
@@ -279,6 +309,8 @@ This option makes the MagSafe LED reflect the charging state of your MacBook (or
 
 Note that you must have a MagSafe LED on your MacBook to use this feature.
 
+This also requires legacy direct charging control. It is unavailable on macOS 27 / 20xxx firmware even if the Mac has a physical MagSafe LED, because firmware owns the charging decision and `batt` cannot reliably mirror its state.
+
 To enable MagSafe LED control, run `sudo batt magsafe-led enable`.
 
 To force the MagSafe LED to stay off, run `sudo batt magsafe-led always-off`.
@@ -312,6 +344,8 @@ This will build the GUI version of `batt` into `./bin/batt.app`. Drag it to `/Ap
 You can think of `batt` like `docker`. It has a daemon that runs in the background, and a client (CLI or GUI) that communicates with the daemon. They communicate through unix domain socket as a way of IPC. The daemon does the actual heavy-lifting, and is responsible for controlling battery charging. The client is responsible for sending users' requirements to the daemon.
 
 For example, when you run `sudo batt limit 80`, the client will send the requirement to the daemon, and the daemon will do its job to keep the charge limit to 80%.
+
+The daemon selects one of two control backends from SMC key presence. The legacy backend continuously reads battery percentage and toggles charging itself. The firmware backend writes lower/upper limits and periodically reconciles them while Apple firmware enforces the range, including during sleep. The same capability data is exposed to CLI and GUI clients so unsupported features are not offered.
 
 ## Motivation
 
@@ -402,6 +436,9 @@ Probably not. `batt` was made Apple-Silicon-only after some early development. I
 
 ### Why does my MacBook stop charging after I close the lid?
 
+> [!NOTE]
+> This FAQ applies only to older firmware using legacy direct charging control. On macOS 27-era `bfF0` firmware, the charge limit persists through sleep and `batt` does not disable charging before sleep.
+
 TL,DR; This is intended, and is the default behavior. It is described [here](#disabling-charging-before-sleep). You can turn this feature off by running `sudo batt disable-charging-pre-sleep disable` (not recommended, keep reading).
 
 But it is suggested to keep the default behavior to make your charge limit work as intended. Why? Because when you close the lid, your MacBook will go into **forced sleep**, and `batt` will be paused by macOS. As a result, `batt` can no longer control battery charging. It will be whatever state it was before you close the lid. This is the problem. Let's say, if you close the lid when your MacBook is charging, since `batt` is paused by macOS, it will keep charging, ignoring the charge limit you have set. There is no way to prevent **forced sleep**. Therefore, the only way to solve this problem is to disable charging before sleep. This is what `batt` does. It will disable charging just before your MacBook goes to sleep, and re-enable it when it wakes up. This way, your Mac will not overcharge during sleep.
@@ -438,11 +475,17 @@ If you want to prevent this, you need to disable sleep globally using pmset, or 
 
 ### My Mac does not start charging after waking up from sleep
 
+> [!NOTE]
+> This FAQ applies only to older firmware using legacy direct charging control. macOS 27-era `bfF0` firmware has no `batt` post-wake delay.
+
 This is expected. batt will prevent your Mac from charging temporarily if your Mac has just woken up from sleep. This is to prevent overcharging during sleep. Your Mac will start charging soon (at most 2 minutes).
 
 If you absolutely need to charge your Mac _immediately_ after waking up from sleep, you can disable this feature by running `sudo batt disable-charging-pre-sleep disable`. However, this is not recommended (see [Disabling charging before sleep](#disabling-charging-before-sleep)).
 
 ### Why does my Mac starts charging after entering sleep?
+
+> [!NOTE]
+> This FAQ applies only to older firmware using legacy direct charging control. On macOS 27-era `bfF0` firmware, Apple firmware continues enforcing the configured range during sleep.
 
 If you are using the default batt settings (i.e., `prevent-idle-sleep` and `disable-charging-pre-sleep` are both enabled), this should not happen.
 

--- a/cmd/batt/advanced.go
+++ b/cmd/batt/advanced.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func NewSetPreventIdleSleepCommand() *cobra.Command {
-	return newEnableDisableCommand(
+	return annotateCapability(newEnableDisableCommand(
 		"prevent-idle-sleep",
 		"Set whether to prevent idle sleep during a charging session",
 		`Set whether to prevent idle sleep during a charging session.
@@ -21,11 +22,11 @@ This option tells macOS NOT to go to sleep when the computer is in a charging se
 However, this options does not prevent manual sleep (limitation of macOS). For example, if you manually put your computer to sleep (by choosing the Sleep option in the top-left Apple menu) or close the lid, batt will still be paused and the issue mentioned above will still happen. This is where disable-charging-pre-sleep comes in.`,
 		func() (string, error) { return apiClient.SetPreventIdleSleep(true) },
 		func() (string, error) { return apiClient.SetPreventIdleSleep(false) },
-	)
+	), compatibility.FeatureSleepHooks)
 }
 
 func NewSetDisableChargingPreSleepCommand() *cobra.Command {
-	return newEnableDisableCommand(
+	return annotateCapability(newEnableDisableCommand(
 		"disable-charging-pre-sleep",
 		"Set whether to disable charging before sleep if charge limit is enabled",
 		`Set whether to disable charging before sleep if charge limit is enabled.
@@ -33,11 +34,11 @@ func NewSetDisableChargingPreSleepCommand() *cobra.Command {
 As described in preventing-idle-sleep, batt will be paused by macOS when your computer goes to sleep, and there is no way for batt to continue controlling battery charging. This option will disable charging just before sleep, so your computer will not overcharge during sleep, even if the battery charge is below the limit.`,
 		func() (string, error) { return apiClient.SetDisableChargingPreSleep(true) },
 		func() (string, error) { return apiClient.SetDisableChargingPreSleep(false) },
-	)
+	), compatibility.FeatureSleepHooks)
 }
 
 func NewSetPreventSystemSleepCommand() *cobra.Command {
-	return newEnableDisableCommand(
+	return annotateCapability(newEnableDisableCommand(
 		"prevent-system-sleep",
 		"Set whether to prevent system sleep during a charging session (experimental)",
 		`This option tells macOS to create power assertion, which prevents sleep, when all conditions are met:
@@ -52,7 +53,7 @@ Does similar thing to prevent-idle-sleep, but works for manual sleep too.
 Note: please disable disable-charging-pre-sleep and prevent-idle-sleep, while this feature is in use`,
 		func() (string, error) { return apiClient.SetPreventSystemSleep(true) },
 		func() (string, error) { return apiClient.SetPreventSystemSleep(false) },
-	)
+	), compatibility.FeatureSleepHooks)
 }
 
 func NewSetControlMagSafeLEDCommand() *cobra.Command {
@@ -115,5 +116,5 @@ func NewSetControlMagSafeLEDCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(enable, disable, alwaysOff)
-	return cmd
+	return annotateCapability(cmd, compatibility.FeatureMagSafeLED)
 }

--- a/cmd/batt/basic.go
+++ b/cmd/batt/basic.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/version"
 )
 
@@ -37,7 +38,7 @@ func NewVersionCommand() *cobra.Command {
 }
 
 func NewLimitCommand() *cobra.Command {
-	return &cobra.Command{
+	return annotateCapability(&cobra.Command{
 		Use:     "limit [percentage]",
 		Short:   "Set upper charge limit",
 		GroupID: gBasic,
@@ -65,11 +66,11 @@ Setting the limit to 10-99 will enable the battery charge limit. However, settin
 
 			return nil
 		},
-	}
+	}, compatibility.FeatureChargingControl)
 }
 
 func NewDisableCommand() *cobra.Command {
-	return &cobra.Command{
+	return annotateCapability(&cobra.Command{
 		Use:     "disable",
 		Short:   "Disable batt",
 		GroupID: gBasic,
@@ -90,7 +91,7 @@ Stop batt from controlling battery charging. This will allow your Mac to charge 
 
 			return nil
 		},
-	}
+	}, compatibility.FeatureChargingControl)
 }
 
 func NewAdapterCommand() *cobra.Command {
@@ -162,7 +163,7 @@ NOTE: if you are using Clamshell mode (using a Mac laptop with an external monit
 		},
 	)
 
-	return cmd
+	return annotateCapability(cmd, compatibility.FeatureAdapterControl)
 }
 
 func NewLowerLimitDeltaCommand() *cobra.Command {
@@ -198,5 +199,5 @@ For example, if you want to set the lower limit to be 5% less than the upper lim
 		},
 	}
 
-	return cmd
+	return annotateCapability(cmd, compatibility.FeatureChargingControl)
 }

--- a/cmd/batt/calibrate.go
+++ b/cmd/batt/calibrate.go
@@ -25,12 +25,18 @@ func NewCalibrationCommand() *cobra.Command {
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start a new calibration session using current config thresholds",
+		Long: `Start a new calibration session using the current thresholds.
+
+batt prevents idle sleep until calibration completes, is cancelled, or fails.
+Closing the lid or explicitly choosing Sleep can still force sleep, so keep the
+lid open during calibration.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			_, err := apiClient.StartCalibration()
 			if err != nil {
 				return fmt.Errorf("failed to start calibration: %w", err)
 			}
-			fmt.Println("Calibration started.")
+			fmt.Println("Calibration started. batt will prevent idle sleep until the session ends.")
+			fmt.Println("Warning: closing the lid or explicitly choosing Sleep can still force sleep; keep the lid open during calibration.")
 			return nil
 		},
 	}

--- a/cmd/batt/calibrate.go
+++ b/cmd/batt/calibrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 )
 
 func NewCalibrationCommand() *cobra.Command {
@@ -144,7 +145,7 @@ Must be between 10 and 1440 minutes (24 hours). Default is 120 minutes.`,
 	}
 
 	cmd.AddCommand(startCmd, pauseCmd, resumeCmd, cancelCmd, statusCmd, dischargeThresholdCmd, holdDurationCmd)
-	return cmd
+	return annotateCapability(cmd, compatibility.FeatureCalibration)
 }
 
 func printCalibrationStatus(st *calibration.Status) {

--- a/cmd/batt/install.go
+++ b/cmd/batt/install.go
@@ -107,14 +107,18 @@ You must run this command as root.`,
 					return fmt.Errorf("failed to open SMC: %v", err)
 				}
 
-				err = smcC.EnableCharging()
-				if err != nil {
-					return fmt.Errorf("failed to enable charging: %v", err)
+				if smcC.IsChargingControlCapable() {
+					err = smcC.ResetChargeControl()
+					if err != nil {
+						return fmt.Errorf("failed to reset charge control: %v", err)
+					}
 				}
 
-				err = smcC.EnableAdapter()
-				if err != nil {
-					return fmt.Errorf("failed to enable adapter: %v", err)
+				if smcC.IsAdapterControlCapable() {
+					err = smcC.EnableAdapter()
+					if err != nil {
+						return fmt.Errorf("failed to enable adapter: %v", err)
+					}
 				}
 
 				if err := smcC.Close(); err != nil {

--- a/cmd/batt/main.go
+++ b/cmd/batt/main.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/charlie0129/batt/pkg/client"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/gui"
 	"github.com/charlie0129/batt/pkg/utils/osver"
 )
@@ -37,6 +38,26 @@ var (
 )
 
 var apiClient *client.Client
+var clientCapabilities = compatibility.Permissive()
+
+const capabilityAnnotation = "batt.requires-capability"
+
+func annotateCapability(cmd *cobra.Command, feature compatibility.Feature) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[capabilityAnnotation] = string(feature)
+	return cmd
+}
+
+func requiredCapability(cmd *cobra.Command) (compatibility.Feature, bool) {
+	for current := cmd; current != nil; current = current.Parent() {
+		if value, ok := current.Annotations[capabilityAnnotation]; ok {
+			return compatibility.Feature(value), true
+		}
+	}
+	return "", false
+}
 
 func setupLogger() error {
 	level, err := logrus.ParseLevel(logLevel)
@@ -105,13 +126,21 @@ func NewCommand() *cobra.Command {
 Website: https://github.com/charlie0129/batt
 Report issues: https://github.com/charlie0129/batt/issues`,
 		SilenceUsage: true,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(selected *cobra.Command, _ []string) error {
 			err := setupLogger()
 			if err != nil {
 				return err
 			}
 
 			apiClient = client.NewClient(unixSocketPath)
+			clientCapabilities = compatibility.Permissive()
+			if detected, err := apiClient.GetCompatibility(); err == nil {
+				clientCapabilities = *detected
+			} else {
+				// An absent daemon or an older daemon without this endpoint must
+				// not prevent commands from running.
+				logrus.WithError(err).Debug("detailed compatibility unavailable; enabling all client features")
+			}
 
 			if clientVersion, daemonVersion, err := getVersion(); err == nil {
 				if daemonVersion != clientVersion {
@@ -124,6 +153,10 @@ Report issues: https://github.com/charlie0129/batt/issues`,
 				if errors.Is(err, client.ErrNotFound) {
 					logrus.Error("batt daemon is too old to report its version. You should follow the installation / upgrade instructions precisely to ensure both client and daemon are the same version.")
 				}
+			}
+
+			if feature, required := requiredCapability(selected); required && !clientCapabilities.Supports(feature) {
+				return fmt.Errorf("%s is not supported on this Mac", feature)
 			}
 
 			return nil

--- a/cmd/batt/main.go
+++ b/cmd/batt/main.go
@@ -42,6 +42,8 @@ var clientCapabilities = compatibility.Permissive()
 
 const capabilityAnnotation = "batt.requires-capability"
 
+const helpCompatibilityTimeout = 500 * time.Millisecond
+
 func annotateCapability(cmd *cobra.Command, feature compatibility.Feature) *cobra.Command {
 	if cmd.Annotations == nil {
 		cmd.Annotations = make(map[string]string)
@@ -57,6 +59,24 @@ func requiredCapability(cmd *cobra.Command) (compatibility.Feature, bool) {
 		}
 	}
 	return "", false
+}
+
+func hideUnsupportedCommands(root *cobra.Command, capabilities compatibility.Capabilities) {
+	for _, cmd := range root.Commands() {
+		if feature, required := requiredCapability(cmd); required {
+			cmd.Hidden = !capabilities.Supports(feature)
+		}
+		hideUnsupportedCommands(cmd, capabilities)
+	}
+}
+
+func capabilitiesForHelp() compatibility.Capabilities {
+	fallback := compatibility.Permissive()
+	detected, err := client.NewClientWithTimeout(unixSocketPath, helpCompatibilityTimeout).GetCompatibility()
+	if err != nil {
+		return fallback
+	}
+	return *detected
 }
 
 func setupLogger() error {
@@ -162,6 +182,11 @@ Report issues: https://github.com/charlie0129/batt/issues`,
 			return nil
 		},
 	}
+	defaultHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(selected *cobra.Command, args []string) {
+		hideUnsupportedCommands(selected.Root(), capabilitiesForHelp())
+		defaultHelp(selected, args)
+	})
 
 	if os.Getenv("BATT_RUN_GUI") != "" || path.Base(os.Args[0]) == "batt-gui" {
 		cmd.Run = func(_ *cobra.Command, _ []string) {

--- a/cmd/batt/main_test.go
+++ b/cmd/batt/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
+)
+
+func TestRequiredCapabilityInheritedFromParentCommand(t *testing.T) {
+	root := &cobra.Command{Use: "batt"}
+	parent := annotateCapability(&cobra.Command{Use: "adapter"}, compatibility.FeatureAdapterControl)
+	child := &cobra.Command{Use: "disable"}
+	parent.AddCommand(child)
+	root.AddCommand(parent)
+
+	got, ok := requiredCapability(child)
+	if !ok || got != compatibility.FeatureAdapterControl {
+		t.Fatalf("requiredCapability() = %q, %t", got, ok)
+	}
+}

--- a/cmd/batt/main_test.go
+++ b/cmd/batt/main_test.go
@@ -20,3 +20,33 @@ func TestRequiredCapabilityInheritedFromParentCommand(t *testing.T) {
 		t.Fatalf("requiredCapability() = %q, %t", got, ok)
 	}
 }
+
+func TestHideUnsupportedCommands(t *testing.T) {
+	root := NewCommand()
+	hideUnsupportedCommands(root, compatibility.Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: compatibility.ChargeControlFirmware,
+	})
+
+	tests := map[string]bool{
+		"limit":                      false,
+		"lower-limit-delta":          false,
+		"status":                     false,
+		"adapter":                    true,
+		"prevent-idle-sleep":         true,
+		"disable-charging-pre-sleep": true,
+		"prevent-system-sleep":       true,
+		"magsafe-led":                true,
+		"calibration":                true,
+		"schedule":                   true,
+	}
+	for name, wantHidden := range tests {
+		cmd, _, err := root.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", name, err)
+		}
+		if cmd.Hidden != wantHidden {
+			t.Errorf("%s hidden = %t, want %t", name, cmd.Hidden, wantHidden)
+		}
+	}
+}

--- a/cmd/batt/schedule.go
+++ b/cmd/batt/schedule.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
 )
 
 func NewScheduleCommand() *cobra.Command {
@@ -43,7 +45,7 @@ The schedule command can be used in multiple ways:
 		newScheduleShowCommand(),
 	)
 
-	return cmd
+	return annotateCapability(cmd, compatibility.FeatureCalibration)
 }
 
 func newScheduleDisableCommand() *cobra.Command {

--- a/cmd/batt/status.go
+++ b/cmd/batt/status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/powerinfo"
 )
@@ -19,6 +20,7 @@ type statusData struct {
 	currentCharge int
 	batteryInfo   *powerinfo.Battery
 	config        *config.RawFileConfig
+	capabilities  compatibility.Capabilities
 }
 
 // computeTimeToLimit calculates the estimated minutes until the charge limit is
@@ -56,19 +58,14 @@ func computeTimeToLimit(data *statusData, cfg *config.File) *int {
 
 // fetchStatusData gathers all data required for the status command from the daemon.
 func fetchStatusData() (*statusData, error) {
-	charging, err := apiClient.GetCharging()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get charging status: %w", err)
+	capabilities := compatibility.Permissive()
+	if detected, err := apiClient.GetCompatibility(); err == nil {
+		capabilities = *detected
 	}
 
 	pluggedIn, err := apiClient.GetPluggedIn()
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if you are plugged in: %w", err)
-	}
-
-	adapter, err := apiClient.GetAdapter()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get power adapter status: %w", err)
 	}
 
 	currentCharge, err := apiClient.GetCurrentCharge()
@@ -86,6 +83,22 @@ func fetchStatusData() (*statusData, error) {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
+	charging := false
+	if capabilities.ChargeControlMode == compatibility.ChargeControlLegacy {
+		charging, err = apiClient.GetCharging()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get charging status: %w", err)
+		}
+	}
+
+	adapter := false
+	if capabilities.AdapterControl {
+		adapter, err = apiClient.GetAdapter()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get power adapter status: %w", err)
+		}
+	}
+
 	return &statusData{
 		charging:      charging,
 		pluggedIn:     pluggedIn,
@@ -93,6 +106,7 @@ func fetchStatusData() (*statusData, error) {
 		currentCharge: currentCharge,
 		batteryInfo:   bat,
 		config:        conf,
+		capabilities:  capabilities,
 	}, nil
 }
 
@@ -121,48 +135,45 @@ func NewStatusCommand() *cobra.Command {
 			// Charging status.
 			cmd.Println(bold("Charging status:"))
 
-			additionalMsg := " (refreshes can take up to 2 minutes)"
-			//nolint:gocritic
-			if data.charging {
-				cmd.Println("  Allow charging: " + bool2Text(true) + additionalMsg)
-				cmd.Print("    Your Mac will charge")
-				if !data.pluggedIn {
-					cmd.Print(", but you are not plugged in yet.") // not plugged in but charging is allowed.
-				} else {
-					cmd.Print(".") // plugged in and charging is allowed.
-				}
-				cmd.Println()
-			} else if cfg.UpperLimit() < 100 {
-				cmd.Println("  Allow charging: " + bool2Text(false) + additionalMsg)
-				cmd.Print("    Your Mac will not charge")
-				if data.pluggedIn {
-					cmd.Print(" even if you plug in")
-				}
-				low := cfg.LowerLimit()
-				if data.currentCharge >= cfg.UpperLimit() {
-					cmd.Print(", because your current charge is above the limit.")
-				} else if data.currentCharge < cfg.UpperLimit() && data.currentCharge >= low {
-					cmd.Print(", because your current charge is above the lower limit. Charging will be allowed after current charge drops below the lower limit.")
-				}
-				if data.pluggedIn && data.currentCharge < low {
-					if data.adapter {
-						cmd.Print(". However, if no manual intervention is involved, charging should be allowed soon. Wait 2 minutes and come back.")
+			switch data.capabilities.ChargeControlMode {
+			case compatibility.ChargeControlFirmware:
+				cmd.Println("  Control mode: " + bold("firmware-managed"))
+				cmd.Println("  Charge limit active: " + bool2Text(cfg.UpperLimit() < 100))
+				cmd.Println("    The firmware decides when to charge and can continue enforcing the limit during sleep.")
+			case compatibility.ChargeControlUnsupported:
+				cmd.Println("  Control mode: " + bold("unsupported"))
+			default:
+				additionalMsg := " (refreshes can take up to 2 minutes)"
+				//nolint:gocritic
+				if data.charging {
+					cmd.Println("  Allow charging: " + bool2Text(true) + additionalMsg)
+					cmd.Print("    Your Mac will charge")
+					if !data.pluggedIn {
+						cmd.Print(", but you are not plugged in yet.")
 					} else {
+						cmd.Print(".")
+					}
+					cmd.Println()
+				} else if cfg.UpperLimit() < 100 {
+					cmd.Println("  Allow charging: " + bool2Text(false) + additionalMsg)
+					cmd.Print("    Your Mac will not charge")
+					low := cfg.LowerLimit()
+					if data.currentCharge >= cfg.UpperLimit() {
+						cmd.Print(", because your current charge is above the limit.")
+					} else if data.currentCharge >= low {
+						cmd.Print(", because your current charge is above the lower limit. Charging will be allowed after current charge drops below the lower limit.")
+					}
+					if data.pluggedIn && data.currentCharge < low && !data.adapter {
 						cmd.Print(", because adapter is disabled.")
 					}
+					cmd.Println()
+				} else {
+					cmd.Println("  Allow charging: " + bool2Text(false) + additionalMsg)
 				}
-				cmd.Println()
-			} else { // not charging and limit is 100%
-				cmd.Println("  Allow charging: " + bool2Text(false) + additionalMsg)
-				cmd.Print("    Your Mac will not charge")
 			}
 
-			if data.adapter {
-				cmd.Println("  Use power adapter: " + bool2Text(true))
-				cmd.Println("    Your Mac will use power from the wall (to operate or charge), if it is plugged in.")
-			} else {
-				cmd.Println("  Use power adapter: " + bool2Text(false))
-				cmd.Println("    Your Mac will not use power from the wall (to operate or charge), even if it is plugged in.")
+			if data.capabilities.AdapterControl {
+				cmd.Println("  Use power adapter: " + bool2Text(data.adapter))
 			}
 
 			cmd.Println()
@@ -217,23 +228,37 @@ func NewStatusCommand() *cobra.Command {
 			} else {
 				cmd.Printf("  Charge limit: %s\n", bold("100%% (batt disabled)"))
 			}
-			cmd.Printf("  Prevent idle-sleep when charging: %s\n", bool2Text(cfg.PreventIdleSleep()))
-			cmd.Printf("  Disable charging before sleep if charge limit is enabled: %s\n", bool2Text(cfg.DisableChargingPreSleep()))
-			cmd.Printf("  Prevent system-sleep when charging: %s\n", bool2Text(cfg.PreventSystemSleep()))
+			if data.capabilities.SleepHooks {
+				cmd.Printf("  Prevent idle-sleep when charging: %s\n", bool2Text(cfg.PreventIdleSleep()))
+				cmd.Printf("  Disable charging before sleep if charge limit is enabled: %s\n", bool2Text(cfg.DisableChargingPreSleep()))
+				cmd.Printf("  Prevent system-sleep when charging: %s\n", bool2Text(cfg.PreventSystemSleep()))
+			} else {
+				cmd.Println("  Legacy sleep controls: " + bold("unsupported/not required"))
+			}
 			cmd.Printf("  Allow non-root users to access the daemon: %s\n", bool2Text(cfg.AllowNonRootAccess()))
 
-			mode := cfg.ControlMagSafeLED()
-			enabled := mode != config.ControlMagSafeModeDisabled
-			ledStatus := bool2Text(enabled)
-			if mode == config.ControlMagSafeModeAlwaysOff {
-				ledStatus += " (" + bold("always off") + ")"
+			if data.capabilities.MagSafeLED {
+				mode := cfg.ControlMagSafeLED()
+				enabled := mode != config.ControlMagSafeModeDisabled
+				ledStatus := bool2Text(enabled)
+				if mode == config.ControlMagSafeModeAlwaysOff {
+					ledStatus += " (" + bold("always off") + ")"
+				}
+				cmd.Printf("  Control MagSafe LED: %s\n", ledStatus)
+			} else {
+				cmd.Println("  Control MagSafe LED: " + bold("unsupported"))
 			}
-			cmd.Printf("  Control MagSafe LED: %s\n", ledStatus)
 
 			cmd.Println()
+			cmd.Println(bold("Hardware compatibility:"))
+			cmd.Printf("  Charge control mode: %s\n", bold("%s", data.capabilities.ChargeControlMode))
+			cmd.Printf("  Sleep hooks: %s\n", bool2Text(data.capabilities.SleepHooks))
+			cmd.Printf("  MagSafe LED control: %s\n", bool2Text(data.capabilities.MagSafeLED))
+			cmd.Printf("  Power adapter control: %s\n", bool2Text(data.capabilities.AdapterControl))
+			cmd.Printf("  Auto calibration: %s\n", bool2Text(data.capabilities.Calibration))
 
 			tr, err := apiClient.GetTelemetry(false, true)
-			if err == nil {
+			if data.capabilities.Calibration && err == nil && tr.Calibration != nil {
 				cmd.Println(bold("Calibration status:"))
 				cmd.Printf("  Phase: %s\n", bold("%s", string(tr.Calibration.Phase)))
 				if tr.Calibration.Phase != calibration.PhaseIdle {

--- a/cmd/batt/status_json.go
+++ b/cmd/batt/status_json.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/powerinfo"
 )
@@ -17,13 +18,14 @@ type statusJSON struct {
 	Battery       statusBatteryJSON  `json:"battery"`
 	Configuration statusConfigJSON   `json:"configuration"`
 	// Calibration is omitted when telemetry data is unavailable (e.g. API error).
-	Calibration *statusCalibrationJSON `json:"calibration,omitempty"`
+	Calibration   *statusCalibrationJSON     `json:"calibration,omitempty"`
+	Compatibility compatibility.Capabilities `json:"compatibility"`
 }
 
 type statusChargingJSON struct {
-	AllowCharging bool `json:"allowCharging"`
-	UseAdapter    bool `json:"useAdapter"`
-	PluggedIn     bool `json:"pluggedIn"`
+	AllowCharging *bool `json:"allowCharging,omitempty"`
+	UseAdapter    *bool `json:"useAdapter,omitempty"`
+	PluggedIn     bool  `json:"pluggedIn"`
 }
 
 type statusBatteryJSON struct {
@@ -96,10 +98,19 @@ func printStatusJSON(cmd *cobra.Command, data *statusData, cfg *config.File) err
 		lowerLimit = upperLimit
 	}
 
+	var allowCharging *bool
+	if data.capabilities.ChargeControlMode == compatibility.ChargeControlLegacy {
+		allowCharging = &data.charging
+	}
+	var useAdapter *bool
+	if data.capabilities.AdapterControl {
+		useAdapter = &data.adapter
+	}
+
 	out := statusJSON{
 		Charging: statusChargingJSON{
-			AllowCharging: data.charging,
-			UseAdapter:    data.adapter,
+			AllowCharging: allowCharging,
+			UseAdapter:    useAdapter,
 			PluggedIn:     data.pluggedIn,
 		},
 		Battery: statusBatteryJSON{
@@ -123,10 +134,11 @@ func printStatusJSON(cmd *cobra.Command, data *statusData, cfg *config.File) err
 				Mode:    string(mode),
 			},
 		},
+		Compatibility: data.capabilities,
 	}
 
 	tr, err := apiClient.GetTelemetry(false, true)
-	if err == nil && tr.Calibration != nil {
+	if data.capabilities.Calibration && err == nil && tr.Calibration != nil {
 		cal := tr.Calibration
 
 		var startedAt *time.Time

--- a/docs/auto-calibration.md
+++ b/docs/auto-calibration.md
@@ -1,6 +1,6 @@
 # Auto Calibration - Design Document
 
-Last updated: 2025-11-11
+Last updated: 2026-07-13
 Owner branch: auto-calibration
 
 ## Goals
@@ -16,7 +16,7 @@ This feature is initiated from the GUI Advanced submenu and orchestrated by the 
 
 ## Non-Goals / Constraints
 
-- Do not interfere with sleep/idle behavior during the discharge phase. The computer should naturally discharge; no sleep assertions will be created.
+- Prevent idle system sleep throughout the calibration session, including while paused. Forced sleep from closing the lid or explicitly choosing Sleep cannot be prevented.
 - No automatic failure/retry strategies. If something goes wrong, the user can Cancel and restore the previous state.
 - No new GUI controls for calibration parameters; they are edited manually in the config file.
 
@@ -55,13 +55,13 @@ Idle → DischargeToThreshold → ChargeToFull → HoldAfterFull → DischargeAf
 
 - DischargeToThreshold
   - Goal: Reach < threshold (default 15%).
-  - Method: Prefer `SetAdapter(false)` or `SetCharging(false)` to prevent charging. Do not create sleep assertions. If adapter control is unavailable, the flow can continue; the GUI may suggest unplugging the adapter for faster discharge.
+  - Method: Disable adapter input while retaining the calibration sleep assertion.
 
 - ChargeToFull
   - Temporarily set upper limit to 100 and enable charging. Wait until the battery reaches 100%.
 
 - HoldAfterFull
-  - After reaching 100%, hold for `calibrationHoldDurationMinutes` (default 120 minutes). Do not create sleep assertions.
+  - After reaching 100%, hold for `calibrationHoldDurationMinutes` (default 120 minutes) while retaining the calibration sleep assertion.
   - If paused during Hold, the effective end time is extended by the paused duration (hold time does not count while paused).
 
 - DischargeAfterHold
@@ -75,6 +75,7 @@ Idle → DischargeToThreshold → ChargeToFull → HoldAfterFull → DischargeAf
 
 - Persist calibration state and original configuration snapshot to disk.
 - On daemon restart, recover to a safe paused state; user can Resume or Cancel from the GUI.
+- Recreate the calibration sleep assertion when restoring an active session after daemon restart.
 
 ### Public API (daemon)
 
@@ -104,8 +105,8 @@ Add RPC endpoints (names illustrative):
 ### Safety
 
 - If the battery is already below the threshold at start, skip to ChargeToFull.
-- If adapter control is missing or charging cannot be toggled, proceed but surface hints to the GUI.
-- No sleep prevention; clamshell/idle/sleep may slow the process naturally.
+- Expose calibration only when adapter control and a supported charge-control backend are available.
+- Hold a `PreventUserIdleSystemSleep` assertion from start until completion, cancellation, or error. Keep it active while paused. This works on AC and battery power but cannot override forced sleep.
 
 ## GUI Design
 
@@ -117,7 +118,7 @@ Add RPC endpoints (names illustrative):
 ### Interactions
 
 - Clicking "Auto Calibration…" shows a confirmation dialog:
-  - Explains the flow and the constraints (no sleep interference; needs to keep the Mac awake for faster completion, etc.).
+  - Explains the flow, automatic idle-sleep prevention, and the forced-sleep limitation.
   - Buttons: Start (default) / Cancel
 
 - Once started, the menu entry changes to a statusful item, e.g.:
@@ -156,6 +157,6 @@ Add RPC endpoints (names illustrative):
 
 ## Open Questions (Resolved by product decision)
 
-- Sleep/idle prevention during discharge: Not desired; do nothing.
+- Sleep/idle prevention: Hold a supported idle-system-sleep assertion for the entire session; forced sleep remains possible.
 - Failure auto-retry policy: None; user cancels manually.
 - GUI editability of parameters: None; edit config file directly.

--- a/pkg/client/apis.go
+++ b/pkg/client/apis.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/events"
 	"github.com/charlie0129/batt/pkg/powerinfo"
@@ -113,6 +114,19 @@ func (c *Client) GetChargingControlCapable() (bool, error) {
 	}
 
 	return capable, nil
+}
+
+// GetCompatibility returns detailed hardware-dependent daemon capabilities.
+func (c *Client) GetCompatibility() (*compatibility.Capabilities, error) {
+	ret, err := c.Get("/compatibility")
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to get compatibility")
+	}
+	var capabilities compatibility.Capabilities
+	if err := json.Unmarshal([]byte(ret), &capabilities); err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to unmarshal compatibility")
+	}
+	return &capabilities, nil
 }
 
 func (c *Client) GetConfig() (*config.RawFileConfig, error) {

--- a/pkg/client/apis_test.go
+++ b/pkg/client/apis_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestGetCompatibility(t *testing.T) {
+	client := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/compatibility" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{
+                "chargingControl": true,
+                "chargeControlMode": "firmware",
+                "sleepHooks": false,
+                "magSafeLED": false,
+                "adapterControl": false,
+                "calibration": false
+            }`)),
+			Header: make(http.Header),
+		}, nil
+	})}}
+
+	got, err := client.GetCompatibility()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.ChargingControl || got.ChargeControlMode != compatibility.ChargeControlFirmware || got.SleepHooks || got.MagSafeLED || got.AdapterControl || got.Calibration {
+		t.Fatalf("unexpected compatibility: %+v", got)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,9 +23,16 @@ type Client struct {
 
 // NewClient is a constructor for creating a new Client
 func NewClient(socketPath string) *Client {
+	return NewClientWithTimeout(socketPath, 0)
+}
+
+// NewClientWithTimeout constructs a client with an optional whole-request
+// timeout. A zero timeout preserves the default behavior.
+func NewClientWithTimeout(socketPath string, timeout time.Duration) *Client {
 	return &Client{
 		socketPath: socketPath,
 		httpClient: &http.Client{
+			Timeout: timeout,
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 					conn, err := net.Dial("unix", socketPath)

--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -1,0 +1,63 @@
+package compatibility
+
+// ChargeControlMode describes how charge limits are enforced on this Mac.
+type ChargeControlMode string
+
+const (
+	ChargeControlUnsupported ChargeControlMode = "unsupported"
+	ChargeControlLegacy      ChargeControlMode = "legacy"
+	ChargeControlFirmware    ChargeControlMode = "firmware"
+)
+
+// Feature identifies a daemon feature that clients may need to gate.
+type Feature string
+
+const (
+	FeatureChargingControl Feature = "charging control"
+	FeatureSleepHooks      Feature = "sleep hooks"
+	FeatureMagSafeLED      Feature = "MagSafe LED control"
+	FeatureAdapterControl  Feature = "power adapter control"
+	FeatureCalibration     Feature = "auto calibration"
+)
+
+// Capabilities reports the hardware-dependent features supported by the daemon.
+type Capabilities struct {
+	ChargingControl   bool              `json:"chargingControl"`
+	ChargeControlMode ChargeControlMode `json:"chargeControlMode"`
+	SleepHooks        bool              `json:"sleepHooks"`
+	MagSafeLED        bool              `json:"magSafeLED"`
+	AdapterControl    bool              `json:"adapterControl"`
+	Calibration       bool              `json:"calibration"`
+}
+
+// Permissive returns the fallback used by clients talking to an older or
+// unavailable daemon. This preserves the historical behavior of exposing all
+// commands when detailed compatibility data cannot be obtained.
+func Permissive() Capabilities {
+	return Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: ChargeControlLegacy,
+		SleepHooks:        true,
+		MagSafeLED:        true,
+		AdapterControl:    true,
+		Calibration:       true,
+	}
+}
+
+// Supports reports whether a named feature is supported.
+func (c Capabilities) Supports(feature Feature) bool {
+	switch feature {
+	case FeatureChargingControl:
+		return c.ChargingControl
+	case FeatureSleepHooks:
+		return c.SleepHooks
+	case FeatureMagSafeLED:
+		return c.MagSafeLED
+	case FeatureAdapterControl:
+		return c.AdapterControl
+	case FeatureCalibration:
+		return c.Calibration
+	default:
+		return true
+	}
+}

--- a/pkg/daemon/calibration.go
+++ b/pkg/daemon/calibration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/events"
 )
 
@@ -25,6 +26,43 @@ var (
 	smcDisableAdapter    = func() error { return smcConn.DisableAdapter() }
 	smcIsPluggedIn       = func() (bool, error) { return smcConn.IsPluggedIn() }
 )
+
+func calibrationNeedsMaintainLoop() bool {
+	calibrationMu.Lock()
+	defer calibrationMu.Unlock()
+	return calibrationState.Phase != calibration.PhaseIdle &&
+		calibrationState.Phase != calibration.PhaseError &&
+		!calibrationState.Paused
+}
+
+func enableChargingForCalibration() error {
+	if capabilities.ChargeControlMode == compatibility.ChargeControlFirmware {
+		_, err := smcConn.EnsureFirmwareChargeLimitDisabled()
+		return err
+	}
+	return smcEnableCharging()
+}
+
+func restoreChargeControlAfterCalibration(st *calibration.State) {
+	if capabilities.ChargeControlMode == compatibility.ChargeControlFirmware {
+		var err error
+		if st.SnapshotMaintain {
+			_, err = smcConn.EnsureFirmwareChargeLimit(st.SnapshotLowerLimit, st.SnapshotUpperLimit)
+		} else {
+			_, err = smcConn.EnsureFirmwareChargeLimitDisabled()
+		}
+		if err != nil {
+			logrus.WithError(err).Error("failed to restore firmware charge limit after calibration")
+		}
+		return
+	}
+
+	if st.SnapshotChargingOn {
+		_ = smcEnableCharging()
+	} else {
+		_ = smcDisableCharging()
+	}
+}
 
 var (
 	calibrationMu        = &sync.Mutex{}
@@ -91,7 +129,10 @@ func startCalibration(threshold, holdMinutes int) error {
 	}
 	upper := conf.UpperLimit()
 	lower := conf.LowerLimit()
-	chargingEnabled, _ := smcIsChargingEnabled()
+	chargingEnabled := true
+	if capabilities.ChargeControlMode != compatibility.ChargeControlFirmware {
+		chargingEnabled, _ = smcIsChargingEnabled()
+	}
 	adapterEnabled, _ := smcIsAdapterEnabled()
 
 	if sseHub != nil {
@@ -173,7 +214,7 @@ func applyCalibrationWithinLoop(charge int) bool {
 				break
 			}
 			logrus.Info("enabling charging")
-			if err := smcEnableCharging(); err != nil {
+			if err := enableChargingForCalibration(); err != nil {
 				st.LastError = err.Error()
 				st.Phase = calibration.PhaseError
 				break
@@ -245,11 +286,7 @@ func applyCalibrationWithinLoop(charge int) bool {
 			st.Phase = calibration.PhaseError
 			break
 		}
-		if st.SnapshotChargingOn {
-			_ = smcEnableCharging()
-		} else {
-			_ = smcDisableCharging()
-		}
+		restoreChargeControlAfterCalibration(st)
 		if st.SnapshotAdapterOn {
 			_ = smcEnableAdapter()
 		} else {
@@ -357,11 +394,7 @@ func cancelCalibration() error {
 		logrus.WithError(err).Warn("failed to save config while canceling calibration")
 	}
 
-	if st.SnapshotChargingOn {
-		_ = smcEnableCharging()
-	} else {
-		_ = smcDisableCharging()
-	}
+	restoreChargeControlAfterCalibration(st)
 	if st.SnapshotAdapterOn {
 		_ = smcEnableAdapter()
 	} else {

--- a/pkg/daemon/calibration.go
+++ b/pkg/daemon/calibration.go
@@ -17,22 +17,43 @@ import (
 
 // smc accessors (function vars) for test seam; default to smcConn methods.
 var (
-	smcGetBatteryCharge  = func() (int, error) { return smcConn.GetBatteryCharge() }
-	smcIsChargingEnabled = func() (bool, error) { return smcConn.IsChargingEnabled() }
-	smcEnableCharging    = func() error { return smcConn.EnableCharging() }
-	smcDisableCharging   = func() error { return smcConn.DisableCharging() }
-	smcIsAdapterEnabled  = func() (bool, error) { return smcConn.IsAdapterEnabled() }
-	smcEnableAdapter     = func() error { return smcConn.EnableAdapter() }
-	smcDisableAdapter    = func() error { return smcConn.DisableAdapter() }
-	smcIsPluggedIn       = func() (bool, error) { return smcConn.IsPluggedIn() }
+	smcGetBatteryCharge     = func() (int, error) { return smcConn.GetBatteryCharge() }
+	smcIsChargingEnabled    = func() (bool, error) { return smcConn.IsChargingEnabled() }
+	smcEnableCharging       = func() error { return smcConn.EnableCharging() }
+	smcDisableCharging      = func() error { return smcConn.DisableCharging() }
+	smcIsAdapterEnabled     = func() (bool, error) { return smcConn.IsAdapterEnabled() }
+	smcEnableAdapter        = func() error { return smcConn.EnableAdapter() }
+	smcDisableAdapter       = func() error { return smcConn.DisableAdapter() }
+	smcIsPluggedIn          = func() (bool, error) { return smcConn.IsPluggedIn() }
+	preventCalibrationSleep = PreventCalibrationSleep
+	allowCalibrationSleep   = AllowCalibrationSleep
 )
+
+func calibrationSessionActive() bool {
+	return calibrationState.Phase != calibration.PhaseIdle && calibrationState.Phase != calibration.PhaseError
+}
+
+func releaseCalibrationSleepAssertion() {
+	if err := allowCalibrationSleep(); err != nil {
+		logrus.WithError(err).Error("failed to release calibration sleep assertion")
+	}
+}
+
+func restoreCalibrationSleepAssertion() {
+	calibrationMu.Lock()
+	defer calibrationMu.Unlock()
+	if !calibrationSessionActive() {
+		return
+	}
+	if err := preventCalibrationSleep(); err != nil {
+		logrus.WithError(err).Error("failed to restore calibration sleep assertion")
+	}
+}
 
 func calibrationNeedsMaintainLoop() bool {
 	calibrationMu.Lock()
 	defer calibrationMu.Unlock()
-	return calibrationState.Phase != calibration.PhaseIdle &&
-		calibrationState.Phase != calibration.PhaseError &&
-		!calibrationState.Paused
+	return calibrationSessionActive() && !calibrationState.Paused
 }
 
 func enableChargingForCalibration() error {
@@ -113,6 +134,9 @@ func startCalibration(threshold, holdMinutes int) error {
 
 	if calibrationState.Phase != calibration.PhaseIdle && calibrationState.Phase != calibration.PhaseError {
 		return ErrCalibrationInProgress
+	}
+	if err := preventCalibrationSleep(); err != nil {
+		return fmt.Errorf("prevent sleep during calibration: %w", err)
 	}
 
 	if threshold < 5 {
@@ -295,6 +319,9 @@ func applyCalibrationWithinLoop(charge int) bool {
 		st.Phase = calibration.PhaseIdle
 	}
 	persistCalibrationState()
+	if st.Phase == calibration.PhaseIdle || st.Phase == calibration.PhaseError {
+		releaseCalibrationSleepAssertion()
+	}
 
 	// Broadcast phase change if any
 	if sseHub != nil && st.Phase != prevPhase {
@@ -411,6 +438,7 @@ func cancelCalibration() error {
 
 	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
 	persistCalibrationState()
+	releaseCalibrationSleepAssertion()
 	return nil
 }
 
@@ -445,6 +473,7 @@ func cancelCalibrationNoRestoreNoError() {
 
 	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
 	persistCalibrationState()
+	releaseCalibrationSleepAssertion()
 }
 
 func getCalibrationStatus() *calibration.Status {

--- a/pkg/daemon/calibration_test.go
+++ b/pkg/daemon/calibration_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charlie0129/gosmc"
 	"github.com/sirupsen/logrus"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
+	"github.com/charlie0129/batt/pkg/smc"
 )
 
 // NOTE: These tests are simplified and mock minimal parts; smcConn and conf must be
@@ -124,5 +127,92 @@ func TestCalibrationFlow(t *testing.T) {
 	applyCalibrationWithinLoop(fake.charge)
 	if calibrationState.Phase != calibration.PhaseIdle {
 		t.Fatalf("expected idle at end, got %s", calibrationState.Phase)
+	}
+}
+
+func TestCalibrationFlowWithFirmwareChargeControl(t *testing.T) {
+	value := func(key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
+		v, err := gosmc.NewValue(key, dataType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+	mock := smc.NewMockValues(
+		value(smc.FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+		value(smc.FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		value(smc.FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		value(smc.AdapterKey1, gosmc.TypeUInt8, 0),
+	)
+	if err := mock.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mock.Close() })
+	if _, err := mock.EnsureFirmwareChargeLimit(78, 80); err != nil {
+		t.Fatal(err)
+	}
+
+	previousSMC, previousConf, previousCapabilities := smcConn, conf, capabilities
+	previousState, previousStatePath := calibrationState, calibrationStatePath
+	previousIsAdapter := smcIsAdapterEnabled
+	previousEnableAdapter, previousDisableAdapter := smcEnableAdapter, smcDisableAdapter
+	t.Cleanup(func() {
+		smcConn, conf, capabilities = previousSMC, previousConf, previousCapabilities
+		calibrationState, calibrationStatePath = previousState, previousStatePath
+		smcIsAdapterEnabled = previousIsAdapter
+		smcEnableAdapter, smcDisableAdapter = previousEnableAdapter, previousDisableAdapter
+	})
+	smcConn = mock
+	conf = &mockConf{upper: 80, lower: 78}
+	capabilities = compatibility.Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: compatibility.ChargeControlFirmware,
+		AdapterControl:    true,
+		Calibration:       true,
+	}
+	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
+	calibrationStatePath = ""
+	smcIsAdapterEnabled = func() (bool, error) { return mock.IsAdapterEnabled() }
+	smcEnableAdapter = func() error { return mock.EnableAdapter() }
+	smcDisableAdapter = func() error { return mock.DisableAdapter() }
+
+	if err := startCalibration(15, 10); err != nil {
+		t.Fatal(err)
+	}
+	applyCalibrationWithinLoop(40)
+	adapterEnabled, err := mock.IsAdapterEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapterEnabled {
+		t.Fatal("adapter should be disabled during discharge")
+	}
+
+	applyCalibrationWithinLoop(14)
+	if calibrationState.Phase != calibration.PhaseCharge {
+		t.Fatalf("phase = %s, want charge", calibrationState.Phase)
+	}
+	firmwareState, err := mock.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firmwareState.Active {
+		t.Fatal("firmware charge limit should be inactive while charging to full")
+	}
+
+	applyCalibrationWithinLoop(100)
+	calibrationState.HoldEndTime = time.Now().Add(-time.Second)
+	applyCalibrationWithinLoop(100)
+	applyCalibrationWithinLoop(80)
+	applyCalibrationWithinLoop(80)
+	if calibrationState.Phase != calibration.PhaseIdle {
+		t.Fatalf("phase = %s, want idle", calibrationState.Phase)
+	}
+	firmwareState, err = mock.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !firmwareState.Active || firmwareState.Lower != 78 || firmwareState.Upper != 80 {
+		t.Fatalf("firmware charge limit was not restored: %+v", firmwareState)
 	}
 }

--- a/pkg/daemon/calibration_test.go
+++ b/pkg/daemon/calibration_test.go
@@ -70,8 +70,32 @@ func (f *fakeSMC) inject() {
 	smcIsPluggedIn = func() (bool, error) { return f.adapter, nil }
 }
 
+type calibrationSleepCalls struct {
+	prevent int
+	allow   int
+}
+
+func stubCalibrationSleep(t *testing.T) *calibrationSleepCalls {
+	t.Helper()
+	previousPrevent, previousAllow := preventCalibrationSleep, allowCalibrationSleep
+	t.Cleanup(func() {
+		preventCalibrationSleep, allowCalibrationSleep = previousPrevent, previousAllow
+	})
+	calls := &calibrationSleepCalls{}
+	preventCalibrationSleep = func() error {
+		calls.prevent++
+		return nil
+	}
+	allowCalibrationSleep = func() error {
+		calls.allow++
+		return nil
+	}
+	return calls
+}
+
 // TestCalibrationFlow simulates the main phase transitions.
 func TestCalibrationFlow(t *testing.T) {
+	sleepCalls := stubCalibrationSleep(t)
 	// Inject mocks
 	fake := newFakeSMC(40, 0, true)
 	fake.inject()
@@ -83,6 +107,15 @@ func TestCalibrationFlow(t *testing.T) {
 	}
 	if calibrationState.Phase != calibration.PhaseDischarge {
 		t.Fatalf("expected discharge phase, got %s", calibrationState.Phase)
+	}
+	if err := pauseCalibration(); err != nil {
+		t.Fatal(err)
+	}
+	if sleepCalls.allow != 0 {
+		t.Fatal("pausing calibration released its sleep assertion")
+	}
+	if err := resumeCalibration(); err != nil {
+		t.Fatal(err)
 	}
 
 	// Move charge below threshold to trigger charging phase
@@ -128,9 +161,13 @@ func TestCalibrationFlow(t *testing.T) {
 	if calibrationState.Phase != calibration.PhaseIdle {
 		t.Fatalf("expected idle at end, got %s", calibrationState.Phase)
 	}
+	if sleepCalls.prevent != 1 || sleepCalls.allow != 1 {
+		t.Fatalf("sleep assertion calls = prevent:%d allow:%d, want 1/1", sleepCalls.prevent, sleepCalls.allow)
+	}
 }
 
 func TestCalibrationFlowWithFirmwareChargeControl(t *testing.T) {
+	sleepCalls := stubCalibrationSleep(t)
 	value := func(key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
 		v, err := gosmc.NewValue(key, dataType, data)
 		if err != nil {
@@ -214,5 +251,8 @@ func TestCalibrationFlowWithFirmwareChargeControl(t *testing.T) {
 	}
 	if !firmwareState.Active || firmwareState.Lower != 78 || firmwareState.Upper != 80 {
 		t.Fatalf("firmware charge limit was not restored: %+v", firmwareState)
+	}
+	if sleepCalls.prevent != 1 || sleepCalls.allow != 1 {
+		t.Fatalf("sleep assertion calls = prevent:%d allow:%d, want 1/1", sleepCalls.prevent, sleepCalls.allow)
 	}
 }

--- a/pkg/daemon/compatibility.go
+++ b/pkg/daemon/compatibility.go
@@ -51,6 +51,7 @@ func disableUnsupportedCalibrationState() {
 		return
 	}
 	logrus.WithField("phase", calibrationState.Phase).Info("discarding unsupported persisted calibration state")
+	releaseCalibrationSleepAssertion()
 	// Calibration may have temporarily changed the configured limit to 100%.
 	// Restore its saved limits without touching unsupported charging/adapter
 	// keys before discarding the workflow state.

--- a/pkg/daemon/compatibility.go
+++ b/pkg/daemon/compatibility.go
@@ -24,9 +24,9 @@ func detectCapabilities() compatibility.Capabilities {
 		// available when the firmware owns charge control.
 		MagSafeLED:     legacy && smcConn.CheckMagSafeExistence(),
 		AdapterControl: adapter,
-		// The calibration workflow requires both direct charge and adapter
-		// control to perform its discharge phases.
-		Calibration: legacy && adapter,
+		// Adapter control performs the discharge phases. Both the legacy and
+		// firmware backends can temporarily allow charging to 100%.
+		Calibration: mode != compatibility.ChargeControlUnsupported && adapter,
 	}
 }
 

--- a/pkg/daemon/compatibility.go
+++ b/pkg/daemon/compatibility.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
+	"github.com/charlie0129/batt/pkg/config"
+)
+
+func detectCapabilities() compatibility.Capabilities {
+	mode := smcConn.ChargeControlMode()
+	legacy := mode == compatibility.ChargeControlLegacy
+	adapter := smcConn.IsAdapterControlCapable()
+	return compatibility.Capabilities{
+		ChargingControl:   mode != compatibility.ChargeControlUnsupported,
+		ChargeControlMode: mode,
+		SleepHooks:        legacy,
+		// LED state follows batt's direct charging state, which is not
+		// available when the firmware owns charge control.
+		MagSafeLED:     legacy && smcConn.CheckMagSafeExistence(),
+		AdapterControl: adapter,
+		// The calibration workflow requires both direct charge and adapter
+		// control to perform its discharge phases.
+		Calibration: legacy && adapter,
+	}
+}
+
+func capabilityLogFields(capabilities compatibility.Capabilities) logrus.Fields {
+	return logrus.Fields{
+		"chargingControl":   capabilities.ChargingControl,
+		"chargeControlMode": capabilities.ChargeControlMode,
+		"sleepHooks":        capabilities.SleepHooks,
+		"magSafeLED":        capabilities.MagSafeLED,
+		"adapterControl":    capabilities.AdapterControl,
+		"calibration":       capabilities.Calibration,
+	}
+}
+
+func disableUnsupportedCalibrationState() {
+	if capabilities.Calibration {
+		return
+	}
+	calibrationMu.Lock()
+	defer calibrationMu.Unlock()
+	if calibrationState.Phase == calibration.PhaseIdle {
+		return
+	}
+	logrus.WithField("phase", calibrationState.Phase).Info("discarding unsupported persisted calibration state")
+	// Calibration may have temporarily changed the configured limit to 100%.
+	// Restore its saved limits without touching unsupported charging/adapter
+	// keys before discarding the workflow state.
+	if calibrationState.SnapshotUpperLimit >= 10 && calibrationState.SnapshotUpperLimit <= 100 &&
+		calibrationState.SnapshotLowerLimit >= 0 && calibrationState.SnapshotLowerLimit < calibrationState.SnapshotUpperLimit {
+		conf.SetUpperLimit(calibrationState.SnapshotUpperLimit)
+		conf.SetLowerLimit(calibrationState.SnapshotLowerLimit)
+		if err := conf.Save(); err != nil {
+			logrus.WithError(err).Error("failed to restore limits from unsupported calibration state")
+		}
+	}
+	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
+	persistCalibrationState()
+}
+
+// disableUnsupportedConfiguredFeatures prevents settings left behind by an
+// OS/firmware upgrade from activating features that are unsafe on the current
+// hardware. It intentionally persists the disabled values.
+func disableUnsupportedConfiguredFeatures() {
+	changed := false
+	if !capabilities.SleepHooks {
+		if conf.PreventIdleSleep() {
+			conf.SetPreventIdleSleep(false)
+			changed = true
+		}
+		if conf.DisableChargingPreSleep() {
+			conf.SetDisableChargingPreSleep(false)
+			changed = true
+		}
+		if conf.PreventSystemSleep() {
+			conf.SetPreventSystemSleep(false)
+			changed = true
+		}
+	}
+	if !capabilities.MagSafeLED && conf.ControlMagSafeLED() != config.ControlMagSafeModeDisabled {
+		conf.SetControlMagSafeLED(config.ControlMagSafeModeDisabled)
+		changed = true
+	}
+	if !capabilities.Calibration && conf.Cron() != "" {
+		conf.SetCron("")
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	if err := conf.Save(); err != nil {
+		logrus.WithError(err).Error("failed to persist disabled unsupported features")
+		return
+	}
+	logrus.WithFields(capabilityLogFields(capabilities)).Info("disabled unsupported configured features")
+}
+
+func requireCapability(c *gin.Context, feature compatibility.Feature) bool {
+	if capabilities.Supports(feature) {
+		return true
+	}
+	err := fmt.Errorf("%s is not supported on this Mac", feature)
+	c.IndentedJSON(http.StatusConflict, err.Error())
+	_ = c.AbortWithError(http.StatusConflict, err)
+	return false
+}
+
+func getCompatibility(c *gin.Context) {
+	c.IndentedJSON(http.StatusOK, capabilities)
+}

--- a/pkg/daemon/compatibility_test.go
+++ b/pkg/daemon/compatibility_test.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/charlie0129/gosmc"
+
+	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
+	"github.com/charlie0129/batt/pkg/config"
+	"github.com/charlie0129/batt/pkg/smc"
+)
+
+func TestUnsupportedFeatureRejectedByDaemon(t *testing.T) {
+	previous := capabilities
+	t.Cleanup(func() { capabilities = previous })
+	capabilities = compatibility.Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: compatibility.ChargeControlFirmware,
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/prevent-idle-sleep", strings.NewReader("true"))
+	setupRoutes().ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+}
+
+func TestDetectCapabilitiesForFirmwareControl(t *testing.T) {
+	value := func(key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
+		v, err := gosmc.NewValue(key, dataType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+	mock := smc.NewMockValues(
+		value(smc.FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+		value(smc.FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		value(smc.FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		value(smc.MagSafeLedKey, gosmc.TypeUInt8, 0),
+	)
+	if err := mock.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mock.Close() })
+
+	previous := smcConn
+	t.Cleanup(func() { smcConn = previous })
+	smcConn = mock
+	got := detectCapabilities()
+	if !got.ChargingControl || got.ChargeControlMode != compatibility.ChargeControlFirmware {
+		t.Fatalf("unexpected charge control capability: %+v", got)
+	}
+	if got.SleepHooks || got.MagSafeLED || got.AdapterControl || got.Calibration {
+		t.Fatalf("unexpected firmware-only capabilities: %+v", got)
+	}
+}
+
+func TestDisableUnsupportedConfiguredFeatures(t *testing.T) {
+	path := t.TempDir() + "/batt.json"
+	file, err := config.NewFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.SetPreventIdleSleep(true)
+	file.SetDisableChargingPreSleep(true)
+	file.SetPreventSystemSleep(true)
+	file.SetControlMagSafeLED(config.ControlMagSafeModeEnabled)
+	file.SetCron("0 10 * * 0")
+
+	previousConf, previousCapabilities := conf, capabilities
+	t.Cleanup(func() { conf, capabilities = previousConf, previousCapabilities })
+	conf = file
+	capabilities = compatibility.Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: compatibility.ChargeControlFirmware,
+	}
+	disableUnsupportedConfiguredFeatures()
+
+	if file.PreventIdleSleep() || file.DisableChargingPreSleep() || file.PreventSystemSleep() {
+		t.Fatal("sleep settings were not disabled")
+	}
+	if file.ControlMagSafeLED() != config.ControlMagSafeModeDisabled {
+		t.Fatal("MagSafe LED control was not disabled")
+	}
+	if file.Cron() != "" {
+		t.Fatal("calibration schedule was not disabled")
+	}
+
+	reloaded, err := config.NewFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.PreventIdleSleep() || reloaded.DisableChargingPreSleep() || reloaded.PreventSystemSleep() || reloaded.Cron() != "" {
+		t.Fatal("disabled settings were not persisted")
+	}
+}
+
+func TestDisableUnsupportedCalibrationRestoresLimits(t *testing.T) {
+	path := t.TempDir() + "/batt.json"
+	file, err := config.NewFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.SetUpperLimit(100)
+	file.SetLowerLimit(98)
+
+	previousConf, previousCapabilities := conf, capabilities
+	previousState, previousStatePath := calibrationState, calibrationStatePath
+	t.Cleanup(func() {
+		conf, capabilities = previousConf, previousCapabilities
+		calibrationState, calibrationStatePath = previousState, previousStatePath
+	})
+	conf = file
+	capabilities = compatibility.Capabilities{ChargeControlMode: compatibility.ChargeControlFirmware}
+	calibrationStatePath = ""
+	calibrationState = &calibration.State{
+		Phase:              calibration.PhaseCharge,
+		SnapshotUpperLimit: 80,
+		SnapshotLowerLimit: 78,
+	}
+
+	disableUnsupportedCalibrationState()
+	if file.UpperLimit() != 80 || file.LowerLimit() != 78 {
+		t.Fatalf("limits = %d/%d, want 80/78", file.UpperLimit(), file.LowerLimit())
+	}
+	if calibrationState.Phase != calibration.PhaseIdle {
+		t.Fatalf("phase = %s, want idle", calibrationState.Phase)
+	}
+}

--- a/pkg/daemon/compatibility_test.go
+++ b/pkg/daemon/compatibility_test.go
@@ -43,6 +43,7 @@ func TestDetectCapabilitiesForFirmwareControl(t *testing.T) {
 		value(smc.FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
 		value(smc.FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
 		value(smc.MagSafeLedKey, gosmc.TypeUInt8, 0),
+		value(smc.AdapterKey1, gosmc.TypeUInt8, 0),
 	)
 	if err := mock.Open(); err != nil {
 		t.Fatal(err)
@@ -56,7 +57,7 @@ func TestDetectCapabilitiesForFirmwareControl(t *testing.T) {
 	if !got.ChargingControl || got.ChargeControlMode != compatibility.ChargeControlFirmware {
 		t.Fatalf("unexpected charge control capability: %+v", got)
 	}
-	if got.SleepHooks || got.MagSafeLED || got.AdapterControl || got.Calibration {
+	if got.SleepHooks || got.MagSafeLED || !got.AdapterControl || !got.Calibration {
 		t.Fatalf("unexpected firmware-only capabilities: %+v", got)
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,14 +16,16 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/events"
 	"github.com/charlie0129/batt/pkg/smc"
 )
 
 var (
-	smcConn *smc.AppleSMC
-	conf    config.Config
+	smcConn      *smc.AppleSMC
+	conf         config.Config
+	capabilities compatibility.Capabilities
 
 	sseHub    *events.EventHub // global hub instance initialized in Run()
 	scheduler *Scheduler
@@ -52,6 +54,7 @@ func setupRoutes() *gin.Engine {
 	router.GET("/current-charge", getCurrentCharge)
 	router.GET("/plugged-in", getPluggedIn)
 	router.GET("/charging-control-capable", getChargingControlCapable)
+	router.GET("/compatibility", getCompatibility)
 	router.GET("/version", getVersion)
 	// Deprecated
 	router.GET("/power-telemetry", getPowerTelemetry)
@@ -75,17 +78,34 @@ func setupRoutes() *gin.Engine {
 }
 
 func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
-	router := setupRoutes()
-
-	// Initialize global SSE hub
-	sseHub = events.NewEventHub()
-
 	var err error
 	conf, err = config.NewFile(configPath)
 	if err != nil {
 		logrus.Fatalf("failed to parse config during startup: %v", err)
 	}
 	logrus.WithFields(conf.LogrusFields()).Infof("config loaded")
+
+	// Open Apple SMC and detect the charge-control mechanism from key
+	// presence before starting any loop, listener, scheduler, or API server.
+	smcConn = smc.New()
+	if err := smcConn.Open(); err != nil {
+		return fmt.Errorf("open Apple SMC: %w", err)
+	}
+	capabilities = detectCapabilities()
+	logrus.WithFields(capabilityLogFields(capabilities)).Info("detected hardware capabilities")
+	disableUnsupportedConfiguredFeatures()
+
+	// Initialize calibration state before the scheduler and main loop can use it.
+	if configPath != "" {
+		dir := filepath.Dir(configPath)
+		initCalibrationState(filepath.Join(dir, "batt.state.json"))
+	} else {
+		initCalibrationState("/etc/batt.state.json")
+	}
+	disableUnsupportedCalibrationState()
+
+	router := setupRoutes()
+	sseHub = events.NewEventHub()
 
 	// Receive SIGHUP to reload config
 	go func() {
@@ -97,6 +117,7 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 				logrus.Errorf("failed to reload config: %v", err)
 				continue
 			}
+			disableUnsupportedConfiguredFeatures()
 			logrus.Infof("config reloaded")
 		}
 	}()
@@ -137,7 +158,7 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 	defer scheduler.Stop()
 
 	// Load persisted schedule from config
-	if cronExpr := conf.Cron(); cronExpr != "" {
+	if cronExpr := conf.Cron(); capabilities.Calibration && cronExpr != "" {
 		if err := scheduler.Schedule(cronExpr); err != nil {
 			logrus.WithError(err).Warn("failed to restore schedule from config")
 		} else {
@@ -172,19 +193,16 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 		}
 	}()
 
-	// Listen to system sleep notifications.
-	go func() {
-		err := listenNotifications()
-		if err != nil {
-			logrus.Errorf("failed to listen to system sleep notifications: %v", err)
-			os.Exit(1)
-		}
-	}()
-
-	// Open Apple SMC for read/writing
-	smcConn = smc.New()
-	if err := smcConn.Open(); err != nil {
-		logrus.Fatal(err)
+	listeningForSleep := capabilities.SleepHooks
+	if listeningForSleep {
+		go func() {
+			if err := listenNotifications(); err != nil {
+				logrus.Errorf("failed to listen to system sleep notifications: %v", err)
+				os.Exit(1)
+			}
+		}()
+	} else {
+		logrus.Info("system sleep notifications are not needed for this charge-control mode")
 	}
 
 	go func() {
@@ -195,14 +213,6 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 		logrus.Errorf("main loop exited unexpectedly")
 	}()
 
-	// Initialize calibration state file next to config path (derive directory from configPath)
-	if configPath != "" {
-		dir := filepath.Dir(configPath)
-		initCalibrationState(filepath.Join(dir, "batt.state.json"))
-	} else {
-		initCalibrationState("/etc/batt.state.json")
-	}
-
 	// Handle common process-killing signals, so we can gracefully shut down:
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
@@ -211,7 +221,7 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 	logrus.Infof("caught signal \"%s\": shutting down.", sig)
 
 	logrus.Info("gracefully shutting down http server")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	err = srv.Shutdown(ctx)
 	if err != nil {
 		logrus.Errorf("failed to gracefully shutdown http server, closing it immediately: %v", err)
@@ -219,19 +229,25 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 	}
 	cancel()
 
-	logrus.Info("stopping listening notifications")
-	stopListeningNotifications()
+	if listeningForSleep {
+		logrus.Info("stopping listening notifications")
+		stopListeningNotifications()
+	}
 
 	if err := AllowSleepOnAC(); err != nil {
 		logrus.Errorf("failed to remove PM assertion before exiting: %v", err)
 	}
 
-	if err := smcConn.EnableCharging(); err != nil {
-		logrus.Errorf("failed to re-enable charging before exiting: %v", err)
+	if capabilities.ChargingControl {
+		if err := smcConn.ResetChargeControl(); err != nil {
+			logrus.Errorf("failed to reset charge control before exiting: %v", err)
+		}
 	}
 
-	if err := smcConn.EnableAdapter(); err != nil {
-		logrus.Errorf("failed to re-enable adapter before exiting: %v", err)
+	if capabilities.AdapterControl {
+		if err := smcConn.EnableAdapter(); err != nil {
+			logrus.Errorf("failed to re-enable adapter before exiting: %v", err)
+		}
 	}
 
 	logrus.Info("closing smc connection")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -103,6 +103,7 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 		initCalibrationState("/etc/batt.state.json")
 	}
 	disableUnsupportedCalibrationState()
+	restoreCalibrationSleepAssertion()
 
 	router := setupRoutes()
 	sseHub = events.NewEventHub()
@@ -236,6 +237,9 @@ func Run(configPath string, unixSocketPath string, allowNonRoot bool) error {
 
 	if err := AllowSleepOnAC(); err != nil {
 		logrus.Errorf("failed to remove PM assertion before exiting: %v", err)
+	}
+	if err := AllowCalibrationSleep(); err != nil {
+		logrus.Errorf("failed to remove calibration sleep assertion before exiting: %v", err)
 	}
 
 	if capabilities.ChargingControl {

--- a/pkg/daemon/handlers.go
+++ b/pkg/daemon/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/peterneutron/powerkit-go/pkg/powerkit"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/powerinfo"
 	"github.com/charlie0129/batt/pkg/version"
@@ -32,6 +33,9 @@ func getLimit(c *gin.Context) {
 }
 
 func setLimit(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureChargingControl) {
+		return
+	}
 	var l int
 	if err := c.BindJSON(&l); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -70,7 +74,11 @@ func setLimit(c *gin.Context) {
 	} else {
 		msg = fmt.Sprintf("set upper/lower charging limit to %d%%/%d%%, current charge: %d%%", conf.UpperLimit(), conf.LowerLimit(), charge)
 		if charge > conf.UpperLimit() {
-			msg += ". Current charge is above the limit, so your computer will use power from the wall only. Battery charge will remain the same."
+			if capabilities.ChargeControlMode == compatibility.ChargeControlFirmware {
+				msg += ". Current charge is above the limit; the firmware may use battery power until it falls within the configured range."
+			} else {
+				msg += ". Current charge is above the limit, so your computer will use power from the wall only. Battery charge will remain the same."
+			}
 		}
 	}
 
@@ -85,6 +93,9 @@ func setLimit(c *gin.Context) {
 }
 
 func setPreventIdleSleep(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureSleepHooks) {
+		return
+	}
 	var p bool
 	if err := c.BindJSON(&p); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -106,6 +117,9 @@ func setPreventIdleSleep(c *gin.Context) {
 }
 
 func setDisableChargingPreSleep(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureSleepHooks) {
+		return
+	}
 	var d bool
 	if err := c.BindJSON(&d); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -127,6 +141,9 @@ func setDisableChargingPreSleep(c *gin.Context) {
 }
 
 func setPreventSystemSleep(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureSleepHooks) {
+		return
+	}
 	var p bool
 	if err := c.BindJSON(&p); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -148,6 +165,9 @@ func setPreventSystemSleep(c *gin.Context) {
 }
 
 func setAdapter(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureAdapterControl) {
+		return
+	}
 	var d bool
 	if err := c.BindJSON(&d); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -177,6 +197,9 @@ func setAdapter(c *gin.Context) {
 }
 
 func getAdapter(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureAdapterControl) {
+		return
+	}
 	enabled, err := smcConn.IsAdapterEnabled()
 	if err != nil {
 		logrus.Errorf("getAdapter failed: %v", err)
@@ -189,6 +212,12 @@ func getAdapter(c *gin.Context) {
 }
 
 func getCharging(c *gin.Context) {
+	if capabilities.ChargeControlMode != compatibility.ChargeControlLegacy {
+		err := fmt.Errorf("direct charging state is not available in %s charge-control mode", capabilities.ChargeControlMode)
+		c.IndentedJSON(http.StatusConflict, err.Error())
+		_ = c.AbortWithError(http.StatusConflict, err)
+		return
+	}
 	charging, err := smcConn.IsChargingEnabled()
 	if err != nil {
 		logrus.Errorf("getCharging failed: %v", err)
@@ -242,6 +271,9 @@ func getBatteryInfo(c *gin.Context) {
 }
 
 func setLowerLimitDelta(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureChargingControl) {
+		return
+	}
 	var d int
 	if err := c.BindJSON(&d); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -273,11 +305,15 @@ func setLowerLimitDelta(c *gin.Context) {
 
 	ret := fmt.Sprintf("set lower limit delta to %d, current upper/lower limit is %d%%/%d%%", d, conf.UpperLimit(), conf.LowerLimit())
 	logrus.Info(ret)
+	maintainLoopForced()
 
 	c.IndentedJSON(http.StatusCreated, ret)
 }
 
 func setControlMagSafeLED(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureMagSafeLED) {
+		return
+	}
 	// Check if MasSafe is supported first. If not, return error.
 	if !smcConn.CheckMagSafeExistence() {
 		logrus.Errorf("setControlMagSafeLED called but there is no MasSafe LED on this device")
@@ -395,7 +431,7 @@ func getUnifiedTelemetry(c *gin.Context) {
 		}
 	}
 
-	if wantCal {
+	if wantCal && capabilities.Calibration {
 		resp["calibration"] = getCalibrationStatus()
 	}
 
@@ -462,6 +498,9 @@ func getEventStream(c *gin.Context) {
 // ===== Calibration Handlers =====
 
 func postStartCalibration(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	// Read threshold & hold from current config getters
 	threshold := conf.CalibrationDischargeThreshold()
 	hold := conf.CalibrationHoldDurationMinutes()
@@ -474,6 +513,9 @@ func postStartCalibration(c *gin.Context) {
 }
 
 func postPauseCalibration(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	if err := pauseCalibration(); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
@@ -483,6 +525,9 @@ func postPauseCalibration(c *gin.Context) {
 }
 
 func postResumeCalibration(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	if err := resumeCalibration(); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
@@ -492,6 +537,9 @@ func postResumeCalibration(c *gin.Context) {
 }
 
 func postCancelCalibration(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	if err := cancelCalibration(); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
@@ -501,6 +549,9 @@ func postCancelCalibration(c *gin.Context) {
 }
 
 func setSchedule(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	var cronExpr string
 	if err := c.BindJSON(&cronExpr); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -524,6 +575,9 @@ func setSchedule(c *gin.Context) {
 }
 
 func skipSchedule(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	if err := skipNextSchedule(); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
@@ -534,6 +588,9 @@ func skipSchedule(c *gin.Context) {
 }
 
 func postponeSchedule(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	var raw string
 	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -563,6 +620,9 @@ func postponeSchedule(c *gin.Context) {
 }
 
 func setCalibrationDischargeThreshold(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	var threshold int
 	if err := c.BindJSON(&threshold); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -598,6 +658,9 @@ func setCalibrationDischargeThreshold(c *gin.Context) {
 }
 
 func setCalibrationHoldDurationMinutes(c *gin.Context) {
+	if !requireCapability(c, compatibility.FeatureCalibration) {
+		return
+	}
 	var minutes int
 	if err := c.BindJSON(&minutes); err != nil {
 		c.IndentedJSON(http.StatusBadRequest, err.Error())

--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/smc"
 )
@@ -77,6 +78,10 @@ func checkMissedMaintainLoops(logStatus bool) bool {
 // prevent parallel runs. So if one maintain loop is already running,
 // the next one will need to wait until the first one finishes.
 func maintainLoop() bool {
+	if capabilities.ChargeControlMode != compatibility.ChargeControlLegacy {
+		return maintainLoopForced()
+	}
+
 	defer loopRecorder.AddRecordNow()
 
 	if conf.PreventSystemSleep() {
@@ -283,6 +288,53 @@ func handleChargingLogic(ignoreMissedLoops, isChargingEnabled, isPluggedIn bool,
 func maintainLoopInner(ignoreMissedLoops bool) bool {
 	maintainLoopInnerLock.Lock()
 	defer maintainLoopInnerLock.Unlock()
+
+	switch capabilities.ChargeControlMode {
+	case compatibility.ChargeControlFirmware:
+		return maintainFirmwareChargeLimit()
+	case compatibility.ChargeControlLegacy:
+		return maintainLegacyCharging(ignoreMissedLoops)
+	default:
+		maintainedChargingInProgress = false
+		return false
+	}
+}
+
+// maintainFirmwareChargeLimit delegates hysteresis enforcement to the
+// firmware. It deliberately does not read battery/charging state or interact
+// with sleep, MagSafe, adapter, or calibration features.
+func maintainFirmwareChargeLimit() bool {
+	upper := conf.UpperLimit()
+	if upper >= 100 {
+		changed, err := smcConn.EnsureFirmwareChargeLimitDisabled()
+		if err != nil {
+			logrus.Errorf("failed to deactivate firmware charge limit: %v", err)
+			return false
+		}
+		if changed {
+			logrus.Info("deactivated firmware charge limit")
+		}
+		maintainedChargingInProgress = false
+		return true
+	}
+
+	lower := conf.LowerLimit()
+	changed, err := smcConn.EnsureFirmwareChargeLimit(lower, upper)
+	if err != nil {
+		logrus.Errorf("failed to reconcile firmware charge limit: %v", err)
+		return false
+	}
+	if changed {
+		logrus.WithFields(logrus.Fields{"lower": lower, "upper": upper}).Info("reconciled firmware charge limit")
+	} else {
+		logrus.WithFields(logrus.Fields{"lower": lower, "upper": upper}).Trace("firmware charge limit is correct")
+	}
+	maintainedChargingInProgress = false
+	return true
+}
+
+// maintainLegacyCharging contains the original batt-managed charge loop.
+func maintainLegacyCharging(ignoreMissedLoops bool) bool {
 
 	upper := conf.UpperLimit()
 	lower := conf.LowerLimit()

--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -304,6 +304,17 @@ func maintainLoopInner(ignoreMissedLoops bool) bool {
 // firmware. It deliberately does not read battery/charging state or interact
 // with sleep, MagSafe, adapter, or calibration features.
 func maintainFirmwareChargeLimit() bool {
+	if calibrationNeedsMaintainLoop() {
+		batteryCharge, err := smcConn.GetBatteryCharge()
+		if err != nil {
+			logrus.Errorf("GetBatteryCharge failed during calibration: %v", err)
+			return false
+		}
+		if applyCalibrationWithinLoop(batteryCharge) {
+			return true
+		}
+	}
+
 	upper := conf.UpperLimit()
 	if upper >= 100 {
 		changed, err := smcConn.EnsureFirmwareChargeLimitDisabled()

--- a/pkg/daemon/loop_test.go
+++ b/pkg/daemon/loop_test.go
@@ -4,6 +4,11 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/charlie0129/gosmc"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
+	"github.com/charlie0129/batt/pkg/smc"
 )
 
 func TestMaintainLoopRecorder_GetRecordsIn(t *testing.T) {
@@ -88,5 +93,59 @@ func TestMaintainLoopRecorder_GetRecordsIn(t *testing.T) {
 				t.Errorf("GetRecordsIn() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMaintainFirmwareChargeLimitWithoutLegacyPolling(t *testing.T) {
+	value := func(key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
+		v, err := gosmc.NewValue(key, dataType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+
+	mock := smc.NewMockValues(
+		value(smc.FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+		value(smc.FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		value(smc.FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+	)
+	if err := mock.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mock.Close() })
+
+	previousSMC, previousConf, previousCapabilities := smcConn, conf, capabilities
+	t.Cleanup(func() {
+		smcConn, conf, capabilities = previousSMC, previousConf, previousCapabilities
+	})
+	smcConn = mock
+	conf = &mockConf{upper: 80, lower: 78}
+	capabilities = compatibility.Capabilities{
+		ChargingControl:   true,
+		ChargeControlMode: compatibility.ChargeControlFirmware,
+	}
+
+	if !maintainLoopForced() {
+		t.Fatal("firmware maintain loop failed")
+	}
+	state, err := mock.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Active || state.Lower != 78 || state.Upper != 80 {
+		t.Fatalf("unexpected firmware state: %+v", state)
+	}
+
+	conf.SetUpperLimit(100)
+	if !maintainLoopForced() {
+		t.Fatal("firmware disable loop failed")
+	}
+	state, err = mock.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Active {
+		t.Fatal("firmware charge limit should be inactive at 100%")
 	}
 }

--- a/pkg/daemon/sleepassertion.go
+++ b/pkg/daemon/sleepassertion.go
@@ -8,6 +8,7 @@ package daemon
 
 // Expose the macro
 const CFStringRef AssertionTypePreventSystemSleep = kIOPMAssertionTypePreventSystemSleep;
+const CFStringRef AssertionTypePreventUserIdleSystemSleep = kIOPMAssertPreventUserIdleSystemSleep;
 const IOPMAssertionID NullAssertionID = kIOPMNullAssertionID;
 */
 import "C"
@@ -17,7 +18,7 @@ import (
 	"unsafe"
 )
 
-func createAssertionSystemSleep(name, details string) (C.IOPMAssertionID, error) {
+func createSleepAssertion(assertionType C.CFStringRef, name, details string) (C.IOPMAssertionID, error) {
 	cname := C.CString(name)
 	cdetail := C.CString(details)
 	defer C.free(unsafe.Pointer(cname))
@@ -38,7 +39,7 @@ func createAssertionSystemSleep(name, details string) (C.IOPMAssertionID, error)
 
 	var assertionID C.IOPMAssertionID
 	status := C.IOPMAssertionCreateWithDescription(
-		C.AssertionTypePreventSystemSleep,
+		assertionType,
 		cfName,
 		cfDetails,
 		0,
@@ -66,7 +67,7 @@ var assertionID C.IOPMAssertionID = C.NullAssertionID
 // PreventSleepOnAC Keeps system in Dark Wake, has effect only on AC
 func PreventSleepOnAC() error {
 	if assertionID == C.NullAssertionID {
-		id, err := createAssertionSystemSleep("batt", "Maintained charging by batt is in progress")
+		id, err := createSleepAssertion(C.AssertionTypePreventSystemSleep, "batt", "Maintained charging by batt is in progress")
 		if err != nil {
 			return err
 		}
@@ -74,6 +75,36 @@ func PreventSleepOnAC() error {
 		assertionID = id
 	}
 	return nil
+}
+
+var calibrationSleepAssertionID C.IOPMAssertionID = C.NullAssertionID
+
+// PreventCalibrationSleep prevents idle system sleep on both battery and AC
+// power. macOS still permits forced sleep, such as closing the lid.
+func PreventCalibrationSleep() error {
+	if calibrationSleepAssertionID != C.NullAssertionID {
+		return nil
+	}
+	id, err := createSleepAssertion(
+		C.AssertionTypePreventUserIdleSystemSleep,
+		"batt auto calibration",
+		"Auto calibration is in progress",
+	)
+	if err != nil {
+		return err
+	}
+	calibrationSleepAssertionID = id
+	return nil
+}
+
+// AllowCalibrationSleep releases the calibration-specific sleep assertion.
+func AllowCalibrationSleep() error {
+	if calibrationSleepAssertionID == C.NullAssertionID {
+		return nil
+	}
+	err := releaseAssertion(calibrationSleepAssertionID)
+	calibrationSleepAssertionID = C.NullAssertionID
+	return err
 }
 
 // AllowSleepOnAC Releases sleep assertion, allowing sleep on AC

--- a/pkg/daemon/sleepcallback.go
+++ b/pkg/daemon/sleepcallback.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/sirupsen/logrus"
 )
@@ -35,6 +36,10 @@ func canSystemSleepCallback() {
 	   seconds then go to sleep.
 	*/
 	logrus.Debugln("received kIOMessageCanSystemSleep notification, idle sleep is about to kick in")
+	if capabilities.ChargeControlMode != compatibility.ChargeControlLegacy {
+		C.AllowPowerChange()
+		return
+	}
 
 	if !conf.PreventIdleSleep() {
 		logrus.Debugln("PreventIdleSleep is disabled, allow idle sleep")
@@ -79,6 +84,10 @@ func systemWillSleepCallback() {
 	   kIOReturnSuccess, however the system WILL still go to sleep.
 	*/
 	logrus.Debugln("received kIOMessageSystemWillSleep notification, system will go to sleep")
+	if capabilities.ChargeControlMode != compatibility.ChargeControlLegacy {
+		C.AllowPowerChange()
+		return
+	}
 
 	if !conf.DisableChargingPreSleep() {
 		logrus.Debugln("DisableChargingPreSleep is disabled, allow sleep")
@@ -138,6 +147,9 @@ func systemWillPowerOnCallback() {
 func systemHasPoweredOnCallback() {
 	// System has finished waking up...
 	logrus.Debugln("received kIOMessageSystemHasPoweredOn notification, system has finished waking up")
+	if capabilities.ChargeControlMode != compatibility.ChargeControlLegacy {
+		return
+	}
 	lastWakeTime = time.Now()
 
 	if scheduler != nil {

--- a/pkg/gui/controller.go
+++ b/pkg/gui/controller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charlie0129/batt/pkg/calibration"
 	"github.com/charlie0129/batt/pkg/client"
+	"github.com/charlie0129/batt/pkg/compatibility"
 	"github.com/charlie0129/batt/pkg/config"
 	"github.com/charlie0129/batt/pkg/powerinfo"
 	"github.com/charlie0129/batt/pkg/version"
@@ -19,6 +20,8 @@ type menuController struct {
 	menu *nativeMenu
 
 	calibrationThreshold int
+	capabilities         compatibility.Capabilities
+	compatibilityKnown   bool
 	eventCancel          context.CancelFunc
 }
 
@@ -36,28 +39,29 @@ func (c *menuController) refreshCompatibility() {
 	rawConfig, err := c.api.GetConfig()
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to get config")
-		c.setCompatibility(false, false, false)
+		c.setCompatibility(false, compatibility.Permissive(), false)
 		return
 	}
 	conf := config.NewFileFromConfig(rawConfig, "")
 	logrus.WithFields(conf.LogrusFields()).Info("Got config")
 
-	logrus.Info("Getting charging control capability")
-	capable, err := c.api.GetChargingControlCapable()
+	logrus.Info("Getting hardware compatibility")
+	capabilities, err := c.api.GetCompatibility()
+	c.compatibilityKnown = err == nil
 	if err != nil {
-		logrus.WithError(err).Warn("Failed to get charging capablility")
-		c.setCompatibility(true, false, false)
-		return
+		logrus.WithError(err).Warn("Detailed compatibility unavailable; enabling all GUI features")
+		fallback := compatibility.Permissive()
+		capabilities = &fallback
 	}
-	logrus.WithField("capable", capable).Info("Got charging control capability")
+	logrus.WithField("capabilities", capabilities).Info("Got hardware compatibility")
 
 	logrus.Info("Getting daemon version")
 	daemonVersion, err := c.api.GetVersion()
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to get version")
-		c.setCompatibility(true, capable, true)
+		c.setCompatibility(true, *capabilities, true)
 	} else {
-		c.setCompatibility(true, capable, daemonVersion != version.Version)
+		c.setCompatibility(true, *capabilities, daemonVersion != version.Version)
 	}
 	logrus.WithFields(logrus.Fields{
 		"daemonVersion": daemonVersion,
@@ -69,32 +73,28 @@ func (c *menuController) refreshOnOpen() {
 	rawConfig, err := c.api.GetConfig()
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get config")
-		c.setCompatibility(false, false, false)
+		c.setCompatibility(false, compatibility.Permissive(), false)
 		return
 	}
-	capable, err := c.api.GetChargingControlCapable()
+	capabilities, err := c.api.GetCompatibility()
+	c.compatibilityKnown = err == nil
 	if err != nil {
-		logrus.WithError(err).Error("Failed to get charging capablility")
-		c.setCompatibility(true, false, false)
-		return
+		logrus.WithError(err).Warn("Detailed compatibility unavailable; enabling all GUI features")
+		fallback := compatibility.Permissive()
+		capabilities = &fallback
 	}
 	daemonVersion, err := c.api.GetVersion()
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get version")
-		c.setCompatibility(true, capable, true)
+		c.setCompatibility(true, *capabilities, true)
 	} else {
-		c.setCompatibility(true, capable, daemonVersion != version.Version)
+		c.setCompatibility(true, *capabilities, daemonVersion != version.Version)
 	}
 	logrus.WithFields(logrus.Fields{
 		"daemonVersion": daemonVersion,
 		"clientVersion": version.Version,
 	}).Info("Got daemon")
 
-	isCharging, err := c.api.GetCharging()
-	if err != nil {
-		c.setStateError("Failed to get charging state", err)
-		return
-	}
 	isPluggedIn, err := c.api.GetPluggedIn()
 	if err != nil {
 		c.setStateError("Failed to get plugged in state", err)
@@ -109,6 +109,14 @@ func (c *menuController) refreshOnOpen() {
 	if err != nil {
 		c.setStateError("Failed to get battery info", err)
 		return
+	}
+	allowsCharging := batteryInfo.State == powerinfo.Charging
+	if capabilities.ChargeControlMode == compatibility.ChargeControlLegacy {
+		allowsCharging, err = c.api.GetCharging()
+		if err != nil {
+			c.setStateError("Failed to get charging state", err)
+			return
+		}
 	}
 
 	conf := config.NewFileFromConfig(rawConfig, "")
@@ -130,7 +138,7 @@ func (c *menuController) refreshOnOpen() {
 	case powerinfo.Full:
 		state = "Full"
 	}
-	if !isCharging && isPluggedIn && conf.UpperLimit() < 100 && currentCharge < conf.LowerLimit() {
+	if capabilities.ChargeControlMode == compatibility.ChargeControlLegacy && !allowsCharging && isPluggedIn && conf.UpperLimit() < 100 && currentCharge < conf.LowerLimit() {
 		state = "Will Charge Soon"
 	}
 	c.menu.setTitle(itemState, "State: "+state)
@@ -139,11 +147,15 @@ func (c *menuController) refreshOnOpen() {
 	c.menu.setChecked(itemPreventIdleSleep, conf.PreventIdleSleep())
 	c.menu.setChecked(itemDisableChargingPreSleep, conf.DisableChargingPreSleep())
 	c.menu.setChecked(itemPreventSystemSleep, conf.PreventSystemSleep())
-	if adapter, err := c.api.GetAdapter(); err == nil {
-		c.menu.setChecked(itemForceDischarge, !adapter)
-	} else {
-		logrus.WithError(err).Error("Failed to get adapter")
-		c.menu.setEnabled(itemForceDischarge, false)
+	if capabilities.AdapterControl {
+		if adapter, err := c.api.GetAdapter(); err == nil {
+			c.menu.setChecked(itemForceDischarge, !adapter)
+		} else {
+			logrus.WithError(err).Error("Failed to get adapter")
+			if c.compatibilityKnown {
+				c.menu.setEnabled(itemForceDischarge, false)
+			}
+		}
 	}
 }
 
@@ -152,34 +164,31 @@ func (c *menuController) setStateError(message string, err error) {
 	c.menu.setTitle(itemState, "State: Error")
 }
 
-func (c *menuController) setCompatibility(installed, capable, needsUpgrade bool) {
+func (c *menuController) setCompatibility(installed bool, capabilities compatibility.Capabilities, needsUpgrade bool) {
 	if value := os.Getenv("BATT_GUI_NO_COMPATIBILITY_CHECK"); value == "1" || value == "true" {
 		return
 	}
-	c.menu.setStatusIcon(installed, capable, needsUpgrade)
+	c.capabilities = capabilities
+	c.menu.setStatusIcon(installed, capabilities.ChargingControl, needsUpgrade)
 
-	usable := installed && capable && !needsUpgrade
+	usable := installed && capabilities.ChargingControl && !needsUpgrade
 	c.menu.setHidden(itemPowerFlow, !usable)
 	c.menu.setHidden(itemInstall, installed)
-	c.menu.setHidden(itemUpgrade, !installed || (!needsUpgrade && capable))
-	c.menu.setHidden(itemState, !installed || !capable)
-	c.menu.setHidden(itemCurrentLimit, !installed || !capable)
+	c.menu.setHidden(itemUpgrade, !installed || (!needsUpgrade && capabilities.ChargingControl))
+	c.menu.setHidden(itemState, !installed || !capabilities.ChargingControl)
+	c.menu.setHidden(itemCurrentLimit, !installed || !capabilities.ChargingControl)
 	c.menu.setHidden(itemQuickLimits, !usable)
 	for _, item := range quickLimitItems {
 		c.menu.setHidden(item, !usable)
 	}
 
 	c.menu.setHidden(itemAdvanced, !installed)
-	for _, item := range []menuItem{
-		itemMagSafe,
-		itemPreventIdleSleep,
-		itemDisableChargingPreSleep,
-		itemPreventSystemSleep,
-		itemForceDischarge,
-		itemAutoCalibration,
-	} {
-		c.menu.setHidden(item, !usable)
-	}
+	c.menu.setHidden(itemMagSafe, !usable || !capabilities.MagSafeLED)
+	c.menu.setHidden(itemPreventIdleSleep, !usable || !capabilities.SleepHooks)
+	c.menu.setHidden(itemDisableChargingPreSleep, !usable || !capabilities.SleepHooks)
+	c.menu.setHidden(itemPreventSystemSleep, !usable || !capabilities.SleepHooks)
+	c.menu.setHidden(itemForceDischarge, !usable || !capabilities.AdapterControl)
+	c.menu.setHidden(itemAutoCalibration, !usable || !capabilities.Calibration)
 	c.menu.setHidden(itemUninstall, !installed)
 	c.menu.setHidden(itemDisableLimit, !usable)
 	if installed {

--- a/pkg/gui/native_alerts.m
+++ b/pkg/gui/native_alerts.m
@@ -10,7 +10,7 @@ void batt_show_alert(const char *message, const char *body) {
     @autoreleasepool {
         NSAlert *alert = [[[NSAlert alloc] init] autorelease];
         alert.icon = [NSImage imageWithSystemSymbolName:@"exclamationmark.triangle"
-                              accessibilityDescription:@"s"];
+                              accessibilityDescription:@"Warning"];
         alert.alertStyle = NSAlertStyleWarning;
         alert.messageText = AlertString(message);
         alert.informativeText = AlertString(body);

--- a/pkg/gui/native_alerts.m
+++ b/pkg/gui/native_alerts.m
@@ -35,14 +35,15 @@ bool batt_show_confirmation(int confirmation) {
             alert.messageText = @"Start Auto Calibration?";
             alert.informativeText =
                 @"This will:\n"
-                 "1. Discharge (to 15% by default) without sleep prevention.\n"
+                 "1. Discharge to 15% by default.\n"
                  "2. Charge to 100%.\n"
                  "3. Hold at full charge (for 2 hours by default).\n"
                  "4. Discharge back to previous charge limit.\n\n"
                  "NOTES:\n"
+                 "• batt will prevent idle sleep until calibration finishes, is cancelled, or fails.\n"
                  "• You can pause or cancel anytime from the menu.\n"
                  "• Highly recommend keeping your Mac connected to power throughout the process to prevent the battery level from dropping below the threshold without timely charging.\n"
-                 "• If you are using Clamshell mode (using a Mac laptop with an external monitor and the lid closed), *the discharging process will cause your Mac to go to sleep*. So you should keep the lid open during the calibration process.";
+                 "• Closing the lid or explicitly choosing Sleep can still force sleep, so keep the lid open during calibration.";
         } else {
             return false;
         }

--- a/pkg/gui/native_tooltips.m
+++ b/pkg/gui/native_tooltips.m
@@ -46,6 +46,7 @@ void BattApplyTooltips(BattMenuController *controller) {
          "NOTE: if you are using Clamshell mode (using a Mac laptop with an external monitor and the lid closed), *cutting power will cause your Mac to go to sleep*. This is a limitation of macOS. There are ways to prevent this, but it is not recommended for most users.");
     SetTooltip(controller, BattItemAutoCalibration,
         @"Calibration helps you calibrate your battery by automatically discharging and charging it according to best practices.\n\n"
+         "batt prevents idle sleep for the entire calibration session. Closing the lid or explicitly choosing Sleep can still force sleep.\n\n"
          "It's recommended to run the calibration process every few months.");
     SetTooltip(controller, BattItemUninstall,
         @"Uninstall the batt daemon. This will remove the batt daemon from your system. You must enter your password to uninstall it.\n\n"

--- a/pkg/smc/adapter.go
+++ b/pkg/smc/adapter.go
@@ -9,6 +9,11 @@ var (
 	ErrNoAdapterCapability = errors.New("no adapter capability found")
 )
 
+// IsAdapterControlCapable reports whether a known adapter-control key exists.
+func (c *AppleSMC) IsAdapterControlCapable() bool {
+	return c.capabilities[AdapterKey1] || c.capabilities[AdapterKey2] || c.capabilities[AdapterKey3]
+}
+
 // IsAdapterEnabled returns whether the adapter is enabled.
 func (c *AppleSMC) IsAdapterEnabled() (bool, error) {
 	logrus.Tracef("IsAdapterEnabled called")

--- a/pkg/smc/charging.go
+++ b/pkg/smc/charging.go
@@ -22,7 +22,9 @@ var (
 // presence, not the macOS version. bfF0 takes precedence because old macOS
 // versions may receive the newer firmware.
 func (c *AppleSMC) ChargeControlMode() compatibility.ChargeControlMode {
-	if c.capabilities[FirmwareChargeLimitActivationKey] {
+	if c.capabilities[FirmwareChargeLimitActivationKey] &&
+		c.capabilities[FirmwareChargeLimitUpperKey] &&
+		c.capabilities[FirmwareChargeLimitLowerKey] {
 		return compatibility.ChargeControlFirmware
 	}
 	if (c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2]) || c.capabilities[ChargingKey3] {

--- a/pkg/smc/charging.go
+++ b/pkg/smc/charging.go
@@ -2,90 +2,212 @@ package smc
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
 )
 
-// IsChargingEnabled returns whether charging is enabled.
-func (c *AppleSMC) IsChargingEnabled() (bool, error) {
-	logrus.Tracef("IsChargingEnabled called")
+var (
+	ErrNoChargingCapability     = errors.New("no charging control capability found")
+	ErrNotLegacyChargeControl   = errors.New("direct charging control is unavailable")
+	ErrNotFirmwareChargeControl = errors.New("firmware charge-limit control is unavailable")
+)
 
-	// Pre-Tahoe firmware versions.
+// ChargeControlMode determines the charge-control mechanism from SMC key
+// presence, not the macOS version. bfF0 takes precedence because old macOS
+// versions may receive the newer firmware.
+func (c *AppleSMC) ChargeControlMode() compatibility.ChargeControlMode {
+	if c.capabilities[FirmwareChargeLimitActivationKey] {
+		return compatibility.ChargeControlFirmware
+	}
+	if (c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2]) || c.capabilities[ChargingKey3] {
+		return compatibility.ChargeControlLegacy
+	}
+	return compatibility.ChargeControlUnsupported
+}
+
+func (c *AppleSMC) IsChargingControlCapable() bool {
+	return c.ChargeControlMode() != compatibility.ChargeControlUnsupported
+}
+
+func (c *AppleSMC) IsDirectChargingControlCapable() bool {
+	return c.ChargeControlMode() == compatibility.ChargeControlLegacy
+}
+
+// IsChargingEnabled returns whether direct, legacy charging is enabled.
+func (c *AppleSMC) IsChargingEnabled() (bool, error) {
+	logrus.Trace("IsChargingEnabled called")
+	if c.ChargeControlMode() != compatibility.ChargeControlLegacy {
+		return false, ErrNotLegacyChargeControl
+	}
+
 	if c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2] {
-		v, err := c.Read(ChargingKey1) // Key1 is enough, we can skip key2.
+		v, err := c.Read(ChargingKey1)
 		if err != nil {
 			return false, err
 		}
-
-		ret := len(v.Bytes) == 1 && v.Bytes[0] == 0x0
-		logrus.Tracef("IsChargingEnabled returned %t", ret)
-
-		return ret, nil
+		return len(v.Bytes) == 1 && v.Bytes[0] == 0x00, nil
 	}
 
-	// Tahoe firmware versions.
 	v, err := c.Read(ChargingKey3)
 	if err != nil {
 		return false, err
 	}
-
-	ret := len(v.Bytes) == 4 && bytes.Equal(v.Bytes, []byte{0x00, 0x00, 0x00, 0x00})
-	logrus.Tracef("IsChargingEnabled returned %t", ret)
-
-	return ret, nil
+	return len(v.Bytes) == 4 && bytes.Equal(v.Bytes, []byte{0x00, 0x00, 0x00, 0x00}), nil
 }
 
-func (c *AppleSMC) IsChargingControlCapable() bool {
-	logrus.Tracef("IsChargingControlCapable called")
-
-	for _, key := range []string{ChargingKey1, ChargingKey2, ChargingKey3} {
-		if c.capabilities[key] {
-			logrus.Tracef("IsChargingControlCapable returned true for key %s", key)
-			return true
-		}
-	}
-
-	return false
-}
-
-// EnableCharging enables charging.
+// EnableCharging enables direct, legacy charging.
 func (c *AppleSMC) EnableCharging() error {
-	logrus.Tracef("EnableCharging called")
-
-	// Pre-Tahoe firmware versions.
-	if c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2] {
-		err := c.Write(ChargingKey1, []byte{0x0})
-		if err != nil {
-			return err
-		}
-		err = c.Write(ChargingKey2, []byte{0x0})
-		if err != nil {
-			return err
-		}
-		return nil
+	logrus.Trace("EnableCharging called")
+	if c.ChargeControlMode() != compatibility.ChargeControlLegacy {
+		return ErrNotLegacyChargeControl
 	}
 
-	// Tahoe firmware versions.
+	if c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2] {
+		if err := c.Write(ChargingKey1, []byte{0x00}); err != nil {
+			return err
+		}
+		return c.Write(ChargingKey2, []byte{0x00})
+	}
 	return c.Write(ChargingKey3, []byte{0x00, 0x00, 0x00, 0x00})
 }
 
-// DisableCharging disables charging.
+// DisableCharging disables direct, legacy charging.
 func (c *AppleSMC) DisableCharging() error {
-	logrus.Tracef("DisableCharging called")
-
-	// Pre-Tahoe firmware versions.
-	if c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2] {
-		err := c.Write(ChargingKey1, []byte{0x2})
-		if err != nil {
-			return err
-		}
-		err = c.Write(ChargingKey2, []byte{0x2})
-		if err != nil {
-			return err
-		}
-		return nil
+	logrus.Trace("DisableCharging called")
+	if c.ChargeControlMode() != compatibility.ChargeControlLegacy {
+		return ErrNotLegacyChargeControl
 	}
 
-	// Tahoe firmware versions.
+	if c.capabilities[ChargingKey1] && c.capabilities[ChargingKey2] {
+		if err := c.Write(ChargingKey1, []byte{0x02}); err != nil {
+			return err
+		}
+		return c.Write(ChargingKey2, []byte{0x02})
+	}
 	return c.Write(ChargingKey3, []byte{0x01, 0x00, 0x00, 0x00})
+}
+
+// FirmwareChargeLimit is the state stored in the macOS 27-era SMC keys.
+type FirmwareChargeLimit struct {
+	Active bool
+	Lower  uint32
+	Upper  uint32
+}
+
+func (c *AppleSMC) readFirmwareLimit(key string) (uint32, error) {
+	v, err := c.Read(key)
+	if err != nil {
+		return 0, err
+	}
+	encoded, err := v.Uint64()
+	if err != nil {
+		return 0, fmt.Errorf("decode %s: %w", key, err)
+	}
+	if encoded > math.MaxUint32 {
+		return 0, fmt.Errorf("decode %s: value %d exceeds uint32", key, encoded)
+	}
+
+	// These firmware keys encode ui32 percentages little-endian (for example,
+	// 50% is 32 00 00 00). gosmc's typed ui32 codec correctly follows the
+	// conventional big-endian SMC representation, so swap the typed value for
+	// these exceptional keys.
+	return bits.ReverseBytes32(uint32(encoded)), nil
+}
+
+// GetFirmwareChargeLimit reads the firmware-managed charge-limit state.
+func (c *AppleSMC) GetFirmwareChargeLimit() (FirmwareChargeLimit, error) {
+	if c.ChargeControlMode() != compatibility.ChargeControlFirmware {
+		return FirmwareChargeLimit{}, ErrNotFirmwareChargeControl
+	}
+
+	activation, err := c.Read(FirmwareChargeLimitActivationKey)
+	if err != nil {
+		return FirmwareChargeLimit{}, err
+	}
+	if len(activation.Bytes) != 1 {
+		return FirmwareChargeLimit{}, fmt.Errorf("%s has incorrect data length %d, want 1", FirmwareChargeLimitActivationKey, len(activation.Bytes))
+	}
+	upper, err := c.readFirmwareLimit(FirmwareChargeLimitUpperKey)
+	if err != nil {
+		return FirmwareChargeLimit{}, err
+	}
+	lower, err := c.readFirmwareLimit(FirmwareChargeLimitLowerKey)
+	if err != nil {
+		return FirmwareChargeLimit{}, err
+	}
+	return FirmwareChargeLimit{Active: activation.Bytes[0] == 0x02, Lower: lower, Upper: upper}, nil
+}
+
+func (c *AppleSMC) writeFirmwareLimit(key string, value uint32) error {
+	return c.WriteUint32(key, bits.ReverseBytes32(value))
+}
+
+// EnsureFirmwareChargeLimit repairs the firmware limit only when it differs
+// from the requested state. The write order is required by the firmware.
+func (c *AppleSMC) EnsureFirmwareChargeLimit(lower, upper int) (bool, error) {
+	if c.ChargeControlMode() != compatibility.ChargeControlFirmware {
+		return false, ErrNotFirmwareChargeControl
+	}
+	if lower < 0 || upper > 100 || lower >= upper {
+		return false, fmt.Errorf("invalid firmware charge limits %d/%d", lower, upper)
+	}
+
+	current, err := c.GetFirmwareChargeLimit()
+	if err != nil {
+		return false, err
+	}
+	if current.Active && current.Lower == uint32(lower) && current.Upper == uint32(upper) {
+		return false, nil
+	}
+
+	if err := c.Write(FirmwareChargeLimitActivationKey, []byte{0x00}); err != nil {
+		return false, err
+	}
+	if err := c.writeFirmwareLimit(FirmwareChargeLimitUpperKey, uint32(upper)); err != nil {
+		return false, err
+	}
+	if err := c.writeFirmwareLimit(FirmwareChargeLimitLowerKey, uint32(lower)); err != nil {
+		return false, err
+	}
+	if err := c.Write(FirmwareChargeLimitActivationKey, []byte{0x02}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// EnsureFirmwareChargeLimitDisabled deactivates a firmware-managed limit.
+func (c *AppleSMC) EnsureFirmwareChargeLimitDisabled() (bool, error) {
+	if c.ChargeControlMode() != compatibility.ChargeControlFirmware {
+		return false, ErrNotFirmwareChargeControl
+	}
+	v, err := c.Read(FirmwareChargeLimitActivationKey)
+	if err != nil {
+		return false, err
+	}
+	if len(v.Bytes) != 1 {
+		return false, fmt.Errorf("%s has incorrect data length %d, want 1", FirmwareChargeLimitActivationKey, len(v.Bytes))
+	}
+	if v.Bytes[0] == 0x00 {
+		return false, nil
+	}
+	return true, c.Write(FirmwareChargeLimitActivationKey, []byte{0x00})
+}
+
+// ResetChargeControl restores the platform's default charging behavior.
+func (c *AppleSMC) ResetChargeControl() error {
+	switch c.ChargeControlMode() {
+	case compatibility.ChargeControlLegacy:
+		return c.EnableCharging()
+	case compatibility.ChargeControlFirmware:
+		_, err := c.EnsureFirmwareChargeLimitDisabled()
+		return err
+	default:
+		return ErrNoChargingCapability
+	}
 }

--- a/pkg/smc/charging_test.go
+++ b/pkg/smc/charging_test.go
@@ -40,6 +40,8 @@ func TestChargeControlModeFromKeys(t *testing.T) {
 				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
 				smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
 				smcValue(t, FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+				smcValue(t, FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+				smcValue(t, FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
 			},
 			want: compatibility.ChargeControlFirmware,
 		},
@@ -49,6 +51,8 @@ func TestChargeControlModeFromKeys(t *testing.T) {
 				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
 				smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
 				smcValue(t, FirmwareChargeLimitActivationKey, gosmc.TypeUInt8),
+				smcValue(t, FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+				smcValue(t, FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
 			},
 			want: compatibility.ChargeControlLegacy,
 		},
@@ -80,7 +84,7 @@ func TestChargeControlModeFromKeys(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := openMockSMC(t, test.values...)
 			if got := client.ChargeControlMode(); got != test.want {
-				t.Fatalf("ChargeControlMode() = %q, want %q", got, test.want)
+				t.Fatalf("ChargeControlMode() = %q, want %q; capabilities=%v", got, test.want, client.capabilities)
 			}
 		})
 	}

--- a/pkg/smc/charging_test.go
+++ b/pkg/smc/charging_test.go
@@ -1,0 +1,168 @@
+package smc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/charlie0129/gosmc"
+
+	"github.com/charlie0129/batt/pkg/compatibility"
+)
+
+func smcValue(t *testing.T, key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
+	t.Helper()
+	value, err := gosmc.NewValue(key, dataType, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func openMockSMC(t *testing.T, values ...gosmc.Value) *AppleSMC {
+	t.Helper()
+	client := NewMockValues(values...)
+	if err := client.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestChargeControlModeFromKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []gosmc.Value
+		want   compatibility.ChargeControlMode
+	}{
+		{
+			name: "firmware key takes precedence",
+			values: []gosmc.Value{
+				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
+				smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
+				smcValue(t, FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+			},
+			want: compatibility.ChargeControlFirmware,
+		},
+		{
+			name: "zero-sized firmware placeholder does not override legacy keys",
+			values: []gosmc.Value{
+				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
+				smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
+				smcValue(t, FirmwareChargeLimitActivationKey, gosmc.TypeUInt8),
+			},
+			want: compatibility.ChargeControlLegacy,
+		},
+		{
+			name: "paired legacy keys",
+			values: []gosmc.Value{
+				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
+				smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
+			},
+			want: compatibility.ChargeControlLegacy,
+		},
+		{
+			name: "Tahoe legacy key",
+			values: []gosmc.Value{
+				smcValue(t, ChargingKey3, gosmc.TypeUInt32, 0, 0, 0, 0),
+			},
+			want: compatibility.ChargeControlLegacy,
+		},
+		{
+			name: "incomplete legacy keys are unsupported",
+			values: []gosmc.Value{
+				smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
+			},
+			want: compatibility.ChargeControlUnsupported,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := openMockSMC(t, test.values...)
+			if got := client.ChargeControlMode(); got != test.want {
+				t.Fatalf("ChargeControlMode() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEnsureFirmwareChargeLimit(t *testing.T) {
+	client := openMockSMC(t,
+		smcValue(t, FirmwareChargeLimitActivationKey, gosmc.TypeUInt8, 0),
+		smcValue(t, FirmwareChargeLimitUpperKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+		smcValue(t, FirmwareChargeLimitLowerKey, gosmc.TypeUInt32, 0, 0, 0, 0),
+	)
+
+	changed, err := client.EnsureFirmwareChargeLimit(48, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected initial reconciliation to change SMC state")
+	}
+
+	state, err := client.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Active || state.Lower != 48 || state.Upper != 50 {
+		t.Fatalf("unexpected firmware state: %+v", state)
+	}
+	upper, err := client.Read(FirmwareChargeLimitUpperKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(upper.Bytes, []byte{0x32, 0x00, 0x00, 0x00}) {
+		t.Fatalf("upper bytes = % x, want little-endian 32 00 00 00", upper.Bytes)
+	}
+
+	changed, err = client.EnsureFirmwareChargeLimit(48, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("correct firmware state should not be rewritten")
+	}
+
+	changed, err = client.EnsureFirmwareChargeLimitDisabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("active limit should be deactivated")
+	}
+	state, err = client.GetFirmwareChargeLimit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Active {
+		t.Fatal("firmware limit is still active")
+	}
+}
+
+func TestLegacyChargingBehavior(t *testing.T) {
+	client := openMockSMC(t,
+		smcValue(t, ChargingKey1, gosmc.TypeUInt8, 0),
+		smcValue(t, ChargingKey2, gosmc.TypeUInt8, 0),
+	)
+	if err := client.DisableCharging(); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err := client.IsChargingEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enabled {
+		t.Fatal("charging should be disabled")
+	}
+	if err := client.EnableCharging(); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err = client.IsChargingEnabled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Fatal("charging should be enabled")
+	}
+}

--- a/pkg/smc/consts_amd64.go
+++ b/pkg/smc/consts_amd64.go
@@ -5,10 +5,43 @@ package smc
 // plan to support Classic Intel MacBooks. However,
 // if we want to, we have something to work on.
 const (
-	MagSafeLedKey    = "ACLC" // Not verified yet.
-	ACPowerKey       = "AC-W" // Not verified yet.
-	ChargingKey1     = "CH0B" // Not verified yet.
-	ChargingKey2     = "CH0C" // Not verified yet.
-	AdapterKey       = "CH0K"
-	BatteryChargeKey = "BBIF"
+	MagSafeLedKey                    = "ACLC" // Not verified yet.
+	ACPowerKey                       = "AC-W" // Not verified yet.
+	ChargingKey1                     = "CH0B" // Not verified yet.
+	ChargingKey2                     = "CH0C" // Not verified yet.
+	ChargingKey3                     = "CHTE" // Not verified yet.
+	FirmwareChargeLimitActivationKey = "bfF0" // Not verified yet.
+	FirmwareChargeLimitUpperKey      = "bfD0" // Not verified yet.
+	FirmwareChargeLimitLowerKey      = "bfE0" // Not verified yet.
+	AdapterKey1                      = "CH0K"
+	AdapterKey2                      = "CH0J"
+	AdapterKey3                      = "CHIE"
+	BatteryChargeKey                 = "BBIF"
+	DCInCurrentKey                   = "ID0R"
+	DCInVoltageKey                   = "VD0R"
+	DCInPowerKey                     = "PDTR"
+	BatteryCurrentKey                = "B0AC"
+	BatteryVoltageKey                = "B0AV"
+	BatteryPowerKey                  = "PPBR"
 )
+
+var allKeys = []string{
+	MagSafeLedKey,
+	ACPowerKey,
+	ChargingKey1,
+	ChargingKey2,
+	ChargingKey3,
+	FirmwareChargeLimitActivationKey,
+	FirmwareChargeLimitUpperKey,
+	FirmwareChargeLimitLowerKey,
+	AdapterKey1,
+	AdapterKey2,
+	AdapterKey3,
+	BatteryChargeKey,
+	DCInCurrentKey,
+	DCInVoltageKey,
+	DCInPowerKey,
+	BatteryCurrentKey,
+	BatteryVoltageKey,
+	BatteryPowerKey,
+}

--- a/pkg/smc/consts_arm64.go
+++ b/pkg/smc/consts_arm64.go
@@ -8,8 +8,13 @@ const (
 	ChargingKey2  = "CH0C"
 	// ChargingKey3 is used for Tahoe firmware versions.
 	ChargingKey3 = "CHTE"
-	AdapterKey1  = "CH0I"
-	AdapterKey2  = "CH0J"
+	// FirmwareChargeLimit* keys are used by macOS 27-era firmware. The
+	// firmware, rather than batt, enforces the configured hysteresis limits.
+	FirmwareChargeLimitActivationKey = "bfF0"
+	FirmwareChargeLimitUpperKey      = "bfD0"
+	FirmwareChargeLimitLowerKey      = "bfE0"
+	AdapterKey1                      = "CH0I"
+	AdapterKey2                      = "CH0J"
 	// AdapterKey3 is used for Tahoe firmware versions.
 	AdapterKey3      = "CHIE"
 	BatteryChargeKey = "BUIC"
@@ -29,6 +34,9 @@ var allKeys = []string{
 	ChargingKey1,
 	ChargingKey2,
 	ChargingKey3,
+	FirmwareChargeLimitActivationKey,
+	FirmwareChargeLimitUpperKey,
+	FirmwareChargeLimitLowerKey,
 	AdapterKey1,
 	AdapterKey2,
 	AdapterKey3,

--- a/pkg/smc/magsafe.go
+++ b/pkg/smc/magsafe.go
@@ -53,8 +53,7 @@ func (c *AppleSMC) GetMagSafeLedState() (MagSafeLedState, error) {
 
 // CheckMagSafeExistence .
 func (c *AppleSMC) CheckMagSafeExistence() bool {
-	_, err := c.Read(MagSafeLedKey)
-	return err == nil
+	return c.capabilities[MagSafeLedKey]
 }
 
 // SetMagSafeCharging .

--- a/pkg/smc/smc.go
+++ b/pkg/smc/smc.go
@@ -38,6 +38,14 @@ func NewMock(prefillValues map[string][]byte) *AppleSMC {
 	}
 }
 
+// NewMockValues returns a mocked AppleSMC with explicitly typed values.
+func NewMockValues(values ...gosmc.Value) *AppleSMC {
+	return &AppleSMC{
+		conn:         gosmc.NewMock(values...),
+		capabilities: make(map[string]bool),
+	}
+}
+
 // Open opens the connection and checks capabilities.
 func (c *AppleSMC) Open() error {
 	err := c.conn.Open()
@@ -78,8 +86,15 @@ func (c *AppleSMC) Read(key string) (gosmc.Value, error) {
 
 // test tells whether the key exists in SMC.
 func (c *AppleSMC) test(key string) bool {
-	_, err := c.Read(key)
-	return err == nil
+	info, err := c.conn.KeyInfo(key)
+	// Some firmware exposes placeholder key metadata with a zero data size.
+	// Such a key cannot be read or written and must not select a control mode.
+	return err == nil && info.DataSize > 0
+}
+
+// HasKey reports whether an SMC key was detected when the connection opened.
+func (c *AppleSMC) HasKey(key string) bool {
+	return c.capabilities[key]
 }
 
 // Write writes a value to SMC.
@@ -99,5 +114,23 @@ func (c *AppleSMC) Write(key string, value []byte) error {
 		"val": value,
 	}).Trace("Write to SMC succeed")
 
+	return nil
+}
+
+// WriteUint32 writes a typed uint32 value to SMC.
+func (c *AppleSMC) WriteUint32(key string, value uint32) error {
+	logrus.WithFields(logrus.Fields{
+		"key": key,
+		"val": value,
+	}).Trace("Trying to write uint32 to SMC")
+
+	if err := c.conn.WriteUint32(key, value); err != nil {
+		return err
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"key": key,
+		"val": value,
+	}).Trace("Write uint32 to SMC succeeded")
 	return nil
 }


### PR DESCRIPTION
Basic charging control support for macOS 27 firmware versions.

The following features are not available:

- sleep hooks: new firmware controls charging by firmware, so sleep hooks are not needed
- magsafe-led: since batt does not manage charging, it only sets the limits, we don't know when to set the magsafe led to which color

Also added capability checks. Menus/Commands like MagSafe LED control will be hidden if host MacBook does not support it.