### PR TITLE
feat: `disable-for` feature hardening and GUI features

### DIFF
--- a/pkg/daemon/calibration.go
+++ b/pkg/daemon/calibration.go
@@ -97,9 +97,13 @@ func restoreChargeControlAfterCalibration(st *calibration.State) {
 }
 
 var (
-	calibrationMu        = &sync.Mutex{}
-	calibrationState     = &calibration.State{Phase: calibration.PhaseIdle}
-	calibrationStatePath = "" // set during daemon Run? Could derive from config path + suffix.
+	// chargeControlTransitionMu serializes admission of calibration and temporary
+	// disable operations so concurrent requests cannot both pass their conflict
+	// checks before either operation persists its state.
+	chargeControlTransitionMu = &sync.Mutex{}
+	calibrationMu             = &sync.Mutex{}
+	calibrationState          = &calibration.State{Phase: calibration.PhaseIdle}
+	calibrationStatePath      = "" // set during daemon Run? Could derive from config path + suffix.
 )
 
 func initCalibrationState(path string) {
@@ -140,11 +144,17 @@ func persistCalibrationState() {
 }
 
 func startCalibration(threshold, holdMinutes int) error {
+	chargeControlTransitionMu.Lock()
+	defer chargeControlTransitionMu.Unlock()
+
 	calibrationMu.Lock()
 	defer calibrationMu.Unlock()
 
 	if calibrationState.Phase != calibration.PhaseIdle && calibrationState.Phase != calibration.PhaseError {
 		return ErrCalibrationInProgress
+	}
+	if !conf.DisableUntil().IsZero() {
+		return ErrTemporaryDisableInProgress
 	}
 	if err := preventCalibrationSleep(); err != nil {
 		return fmt.Errorf("prevent sleep during calibration: %w", err)
@@ -199,6 +209,8 @@ func startCalibration(threshold, holdMinutes int) error {
 var ErrCalibrationInProgress = &calibrationError{"calibration already in progress"}
 var ErrCalibrationNotRunning = &calibrationError{"calibration not running"}
 var ErrCalibrationPaused = &calibrationError{"calibration paused"}
+var ErrCalibrationControlsChargeLimit = &calibrationError{"a calibration is in progress or awaiting cancellation, which controls the charge limit itself. Cancel it first with 'batt calibration cancel'"}
+var ErrTemporaryDisableInProgress = &calibrationError{"a temporary charge-limit disable is in progress; wait for it to finish or set a charge limit to cancel it"}
 
 type calibrationError struct{ msg string }
 

--- a/pkg/daemon/calibration_test.go
+++ b/pkg/daemon/calibration_test.go
@@ -105,6 +105,33 @@ func stubCalibrationSleep(t *testing.T) *calibrationSleepCalls {
 	return calls
 }
 
+func TestStartCalibrationRejectsTemporaryDisable(t *testing.T) {
+	previousConf, previousState, previousStatePath := conf, calibrationState, calibrationStatePath
+	t.Cleanup(func() {
+		conf, calibrationState, calibrationStatePath = previousConf, previousState, previousStatePath
+	})
+
+	sleepCalls := stubCalibrationSleep(t)
+	conf = &mockConf{
+		upper:           100,
+		lower:           78,
+		disableUntil:    time.Now().Add(time.Hour),
+		preDisableLimit: 80,
+	}
+	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
+	calibrationStatePath = ""
+
+	if err := startCalibration(15, 10); err != ErrTemporaryDisableInProgress {
+		t.Fatalf("startCalibration() error = %v, want %v", err, ErrTemporaryDisableInProgress)
+	}
+	if calibrationState.Phase != calibration.PhaseIdle {
+		t.Fatalf("phase = %s, want idle", calibrationState.Phase)
+	}
+	if sleepCalls.prevent != 0 {
+		t.Fatal("rejected calibration acquired a sleep assertion")
+	}
+}
+
 // TestCalibrationFlow simulates the main phase transitions.
 func TestCalibrationFlow(t *testing.T) {
 	sleepCalls := stubCalibrationSleep(t)

--- a/pkg/daemon/handlers.go
+++ b/pkg/daemon/handlers.go
@@ -50,6 +50,16 @@ func setLimit(c *gin.Context) {
 		return
 	}
 
+	chargeControlTransitionMu.Lock()
+	defer chargeControlTransitionMu.Unlock()
+
+	if calibrationOwnsChargeLimit() {
+		err := ErrCalibrationControlsChargeLimit
+		c.IndentedJSON(http.StatusBadRequest, err.Error())
+		_ = c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	if delta := conf.UpperLimit() - conf.LowerLimit(); l-delta <= 10 {
 		err := fmt.Errorf("upper limit must be greater than lower limit + 10, got %d", l-delta)
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
@@ -139,8 +149,11 @@ func setDisableFor(c *gin.Context) {
 		return
 	}
 
+	chargeControlTransitionMu.Lock()
+	defer chargeControlTransitionMu.Unlock()
+
 	if calibrationOwnsChargeLimit() {
-		err := fmt.Errorf("a calibration is in progress or awaiting cancellation, which controls the charge limit itself. Cancel it first with 'batt calibration cancel'")
+		err := ErrCalibrationControlsChargeLimit
 		c.IndentedJSON(http.StatusBadRequest, err.Error())
 		_ = c.AbortWithError(http.StatusBadRequest, err)
 		return

--- a/pkg/daemon/handlers_test.go
+++ b/pkg/daemon/handlers_test.go
@@ -1,8 +1,14 @@
 package daemon
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/charlie0129/batt/pkg/calibration"
+	"github.com/charlie0129/batt/pkg/compatibility"
 )
 
 func TestResolveDisableLimit(t *testing.T) {
@@ -65,5 +71,102 @@ func TestResolveDisableLimit(t *testing.T) {
 				t.Errorf("resolveDisableLimit() = (%d, %v), want (%d, %v)", got, gotOK, tt.want, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestSetDisableForRejectsCalibration(t *testing.T) {
+	previousConf, previousCapabilities := conf, capabilities
+	previousState, previousStatePath := calibrationState, calibrationStatePath
+	t.Cleanup(func() {
+		conf, capabilities = previousConf, previousCapabilities
+		calibrationState, calibrationStatePath = previousState, previousStatePath
+	})
+
+	configured := &mockConf{upper: 80, lower: 78}
+	conf = configured
+	capabilities = compatibility.Capabilities{ChargingControl: true}
+	calibrationState = &calibration.State{Phase: calibration.PhaseCharge}
+	calibrationStatePath = ""
+
+	request := httptest.NewRequest(http.MethodPut, "/disable", strings.NewReader(`"1h0m0s"`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", response.Code, http.StatusBadRequest, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "calibration is in progress") {
+		t.Fatalf("response does not explain conflict: %s", response.Body.String())
+	}
+	if configured.upper != 80 || !configured.disableUntil.IsZero() {
+		t.Fatalf("temporary disable mutated config after rejection: %+v", configured)
+	}
+}
+
+func TestSetLimitRejectsCalibration(t *testing.T) {
+	previousConf, previousCapabilities := conf, capabilities
+	previousState, previousStatePath := calibrationState, calibrationStatePath
+	t.Cleanup(func() {
+		conf, capabilities = previousConf, previousCapabilities
+		calibrationState, calibrationStatePath = previousState, previousStatePath
+	})
+
+	for _, phase := range []calibration.Phase{calibration.PhaseCharge, calibration.PhaseError} {
+		t.Run(string(phase), func(t *testing.T) {
+			configured := &mockConf{upper: 80, lower: 78}
+			conf = configured
+			capabilities = compatibility.Capabilities{ChargingControl: true}
+			calibrationState = &calibration.State{Phase: phase}
+			calibrationStatePath = ""
+
+			request := httptest.NewRequest(http.MethodPut, "/limit", strings.NewReader("90"))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			setupRoutes().ServeHTTP(response, request)
+
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body: %s", response.Code, http.StatusBadRequest, response.Body.String())
+			}
+			if !strings.Contains(response.Body.String(), ErrCalibrationControlsChargeLimit.Error()) {
+				t.Fatalf("response does not explain conflict: %s", response.Body.String())
+			}
+			if configured.upper != 80 {
+				t.Fatalf("upper limit = %d after rejection, want 80", configured.upper)
+			}
+		})
+	}
+}
+
+func TestStartCalibrationRequestRejectsTemporaryDisable(t *testing.T) {
+	previousConf, previousCapabilities := conf, capabilities
+	previousState, previousStatePath := calibrationState, calibrationStatePath
+	t.Cleanup(func() {
+		conf, capabilities = previousConf, previousCapabilities
+		calibrationState, calibrationStatePath = previousState, previousStatePath
+	})
+
+	conf = &mockConf{
+		upper:           100,
+		lower:           78,
+		disableUntil:    time.Now().Add(time.Hour),
+		preDisableLimit: 80,
+	}
+	capabilities = compatibility.Capabilities{Calibration: true}
+	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
+	calibrationStatePath = ""
+
+	request := httptest.NewRequest(http.MethodPost, "/calibration/start", nil)
+	response := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", response.Code, http.StatusBadRequest, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), ErrTemporaryDisableInProgress.Error()) {
+		t.Fatalf("response does not explain conflict: %s", response.Body.String())
+	}
+	if calibrationState.Phase != calibration.PhaseIdle {
+		t.Fatalf("phase = %s, want idle", calibrationState.Phase)
 	}
 }

--- a/pkg/daemon/loop.go
+++ b/pkg/daemon/loop.go
@@ -38,13 +38,18 @@ func infiniteLoop() {
 // restoreDisabledLimit restores the upper limit saved by a "batt disable --for"
 // once its deadline has passed. It reports whether the limit was restored.
 func restoreDisabledLimit(conf config.Config, now time.Time) bool {
+	chargeControlTransitionMu.Lock()
+	defer chargeControlTransitionMu.Unlock()
+
 	until := conf.DisableUntil()
 	if until.IsZero() || now.Before(until) {
 		return false
 	}
 
 	// Calibration force-writes the upper limit it snapshotted when it finishes,
-	// which would silently undo the restore. Keep the timer pending until then.
+	// which would silently undo the restore. This also resolves persisted
+	// conflicts after a daemon restart: calibration keeps ownership and the
+	// timer remains pending until calibration finishes or is cancelled.
 	if calibrationOwnsChargeLimit() {
 		return false
 	}
@@ -214,10 +219,20 @@ func handleNoMaintain(isChargingEnabled bool) bool {
 		logrus.Errorf("AllowSleepOnAC failed: %v", err)
 	}
 
-	cancelCalibrationNoRestoreNoError()
+	cancelCalibrationForPermanentDisable()
 
 	maintainedChargingInProgress = false
 	return true
+}
+
+func cancelCalibrationForPermanentDisable() {
+	// A persisted temporary-disable/calibration conflict can be loaded after a
+	// restart. Calibration is restored paused for safety, so keep it intact and
+	// let the disable timer wait for the user to resume or cancel calibration.
+	if !conf.DisableUntil().IsZero() {
+		return
+	}
+	cancelCalibrationNoRestoreNoError()
 }
 
 func handleChargingLogic(ignoreMissedLoops, isChargingEnabled, isPluggedIn bool, batteryCharge, lower, upper int) bool {

--- a/pkg/daemon/loop_test.go
+++ b/pkg/daemon/loop_test.go
@@ -201,6 +201,53 @@ func TestRestoreDisabledLimit(t *testing.T) {
 	}
 }
 
+func TestRestoreDisabledLimitWaitsForPersistedCalibration(t *testing.T) {
+	previousState := calibrationState
+	t.Cleanup(func() { calibrationState = previousState })
+
+	now := time.Now()
+	configured := &mockConf{
+		upper:           100,
+		lower:           78,
+		disableUntil:    now.Add(-time.Hour),
+		preDisableLimit: 80,
+	}
+	calibrationState = &calibration.State{Phase: calibration.PhaseCharge}
+
+	if restoreDisabledLimit(configured, now) {
+		t.Fatal("temporary disable restored while calibration owned the charge limit")
+	}
+	if configured.disableUntil.IsZero() {
+		t.Fatal("temporary disable timer was cleared while calibration was active")
+	}
+
+	calibrationState = &calibration.State{Phase: calibration.PhaseIdle}
+	if !restoreDisabledLimit(configured, now) {
+		t.Fatal("temporary disable was not restored after calibration finished")
+	}
+	if configured.upper != 80 || !configured.disableUntil.IsZero() {
+		t.Fatalf("restored config = %+v, want upper 80 with no timer", configured)
+	}
+}
+
+func TestTemporaryDisableDoesNotCancelRestartedCalibration(t *testing.T) {
+	previousConf, previousState := conf, calibrationState
+	t.Cleanup(func() { conf, calibrationState = previousConf, previousState })
+
+	conf = &mockConf{
+		upper:           100,
+		lower:           78,
+		disableUntil:    time.Now().Add(time.Hour),
+		preDisableLimit: 80,
+	}
+	calibrationState = &calibration.State{Phase: calibration.PhaseCharge, Paused: true}
+
+	cancelCalibrationForPermanentDisable()
+	if calibrationState.Phase != calibration.PhaseCharge || !calibrationState.Paused {
+		t.Fatalf("persisted calibration was unexpectedly cancelled: %+v", calibrationState)
+	}
+}
+
 func TestMaintainFirmwareChargeLimitWithoutLegacyPolling(t *testing.T) {
 	value := func(key string, dataType gosmc.DataType, data ...byte) gosmc.Value {
 		v, err := gosmc.NewValue(key, dataType, data)

--- a/pkg/gui/actions.go
+++ b/pkg/gui/actions.go
@@ -1,7 +1,10 @@
 package gui
 
 import (
+	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,8 +43,18 @@ func (c *menuController) handleAction(item menuItem, checked bool) {
 		c.cancelCalibration()
 	case itemUninstall:
 		c.uninstall()
-	case itemDisableLimit:
+	case itemDisableLimitIndefinitely:
 		c.disableLimit()
+	case itemDisableLimit1Hour,
+		itemDisableLimit2Hours,
+		itemDisableLimit4Hours,
+		itemDisableLimit8Hours,
+		itemDisableLimit12Hours,
+		itemDisableLimit24Hours,
+		itemDisableLimit2Days,
+		itemDisableLimit3Days,
+		itemDisableLimit7Days:
+		c.disableLimitFor(temporaryDisableDuration(item))
 	case itemQuit:
 		c.quit()
 	}
@@ -167,8 +180,67 @@ func (c *menuController) uninstall() {
 func (c *menuController) disableLimit() {
 	response, err := c.api.SetLimit(100)
 	if err != nil && !pkgerrors.Is(err, client.ErrDaemonNotRunning) {
-		showAlert("Failed to set limit", response+err.Error())
+		showAlert("Failed to disable charge limit", response+err.Error())
 	}
+}
+
+func (c *menuController) disableLimitFor(duration time.Duration) {
+	response, err := c.api.DisableFor(duration)
+	if err != nil && !pkgerrors.Is(err, client.ErrDaemonNotRunning) {
+		showAlert("Failed to disable charge limit", response+err.Error())
+	}
+}
+
+func temporaryDisableDuration(item menuItem) time.Duration {
+	switch item {
+	case itemDisableLimit1Hour:
+		return time.Hour
+	case itemDisableLimit2Hours:
+		return 2 * time.Hour
+	case itemDisableLimit4Hours:
+		return 4 * time.Hour
+	case itemDisableLimit8Hours:
+		return 8 * time.Hour
+	case itemDisableLimit12Hours:
+		return 12 * time.Hour
+	case itemDisableLimit24Hours:
+		return 24 * time.Hour
+	case itemDisableLimit2Days:
+		return 2 * 24 * time.Hour
+	case itemDisableLimit3Days:
+		return 3 * 24 * time.Hour
+	case itemDisableLimit7Days:
+		return 7 * 24 * time.Hour
+	default:
+		panic("not a temporary disable menu item")
+	}
+}
+
+func temporaryDisableCountdownTitle(limit int, remaining time.Duration) string {
+	if remaining <= 0 {
+		return fmt.Sprintf("Restoring %d%% limit…", limit)
+	}
+
+	totalMinutes := int64(remaining / time.Minute)
+	if remaining%time.Minute != 0 {
+		totalMinutes++
+	}
+
+	days := totalMinutes / (24 * 60)
+	hours := totalMinutes % (24 * 60) / 60
+	minutes := totalMinutes % 60
+	parts := make([]string, 0, 3)
+	if days > 0 {
+		parts = append(parts, fmt.Sprintf("%dd", days))
+	}
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", hours))
+	}
+	if minutes > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", minutes))
+	}
+
+	return fmt.Sprintf("Restores to %d%% in %s", limit, strings.Join(parts, " "))
 }
 
 func (c *menuController) quit() {

--- a/pkg/gui/actions_test.go
+++ b/pkg/gui/actions_test.go
@@ -1,0 +1,50 @@
+package gui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTemporaryDisableDuration(t *testing.T) {
+	tests := []struct {
+		item menuItem
+		want time.Duration
+	}{
+		{item: itemDisableLimit1Hour, want: time.Hour},
+		{item: itemDisableLimit2Hours, want: 2 * time.Hour},
+		{item: itemDisableLimit4Hours, want: 4 * time.Hour},
+		{item: itemDisableLimit8Hours, want: 8 * time.Hour},
+		{item: itemDisableLimit12Hours, want: 12 * time.Hour},
+		{item: itemDisableLimit24Hours, want: 24 * time.Hour},
+		{item: itemDisableLimit2Days, want: 2 * 24 * time.Hour},
+		{item: itemDisableLimit3Days, want: 3 * 24 * time.Hour},
+		{item: itemDisableLimit7Days, want: 7 * 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		if got := temporaryDisableDuration(tt.item); got != tt.want {
+			t.Errorf("temporaryDisableDuration(%d) = %s, want %s", tt.item, got, tt.want)
+		}
+	}
+}
+
+func TestTemporaryDisableCountdownTitle(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining time.Duration
+		want      string
+	}{
+		{name: "days", remaining: 7 * 24 * time.Hour, want: "Restores to 80% in 7d"},
+		{name: "composite", remaining: 49*time.Hour + time.Minute, want: "Restores to 80% in 2d 1h 1m"},
+		{name: "rounds up partial minute", remaining: 30 * time.Second, want: "Restores to 80% in 1m"},
+		{name: "elapsed", remaining: 0, want: "Restoring 80% limit…"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := temporaryDisableCountdownTitle(80, tt.remaining); got != tt.want {
+				t.Errorf("temporaryDisableCountdownTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/gui/controller.go
+++ b/pkg/gui/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -22,6 +23,7 @@ type menuController struct {
 	calibrationThreshold int
 	capabilities         compatibility.Capabilities
 	compatibilityKnown   bool
+	disableScheduled     bool
 	eventCancel          context.CancelFunc
 }
 
@@ -31,6 +33,7 @@ func (c *menuController) onWillOpen() {
 }
 
 func (c *menuController) onTimerTick() {
+	c.refreshDisableSchedule()
 	c.updateTelemetry()
 }
 
@@ -76,6 +79,10 @@ func (c *menuController) refreshOnOpen() {
 		c.setCompatibility(false, compatibility.Permissive(), false)
 		return
 	}
+	conf := config.NewFileFromConfig(rawConfig, "")
+	logrus.WithFields(conf.LogrusFields()).Info("Got config")
+	c.updateDisableSchedule(conf)
+
 	capabilities, err := c.api.GetCompatibility()
 	c.compatibilityKnown = err == nil
 	if err != nil {
@@ -119,8 +126,6 @@ func (c *menuController) refreshOnOpen() {
 		}
 	}
 
-	conf := config.NewFileFromConfig(rawConfig, "")
-	logrus.WithFields(conf.LogrusFields()).Info("Got config")
 	c.calibrationThreshold = conf.CalibrationDischargeThreshold()
 	c.menu.setTitle(itemCurrentLimit, fmt.Sprintf("Current Limit: %d%%", conf.UpperLimit()))
 	for _, item := range quickLimitItems {
@@ -157,6 +162,38 @@ func (c *menuController) refreshOnOpen() {
 			}
 		}
 	}
+}
+
+func (c *menuController) refreshDisableSchedule() {
+	rawConfig, err := c.api.GetConfig()
+	if err != nil {
+		logrus.WithError(err).Debug("Failed to refresh temporary disable schedule")
+		return
+	}
+	c.updateDisableSchedule(config.NewFileFromConfig(rawConfig, ""))
+}
+
+func (c *menuController) updateDisableSchedule(conf config.Config) {
+	until := conf.DisableUntil()
+	scheduled := !until.IsZero()
+	c.disableScheduled = scheduled
+	for _, item := range disableLimitActionItems {
+		c.menu.setEnabled(item, !scheduled)
+	}
+	c.menu.setHidden(itemDisableLimitCountdown, !scheduled)
+
+	if !scheduled {
+		c.menu.setTooltip(itemDisableLimit, disableLimitTooltip)
+		return
+	}
+
+	c.menu.setEnabled(itemDisableLimit, true)
+	c.menu.setTitle(
+		itemDisableLimitCountdown,
+		temporaryDisableCountdownTitle(conf.PreDisableLimit(), time.Until(until)),
+	)
+	c.menu.setTooltip(itemDisableLimit, disableLimitScheduledTooltip)
+	c.menu.setTooltip(itemDisableLimitCountdown, disableLimitScheduledTooltip)
 }
 
 func (c *menuController) setStateError(message string, err error) {
@@ -240,10 +277,10 @@ func (c *menuController) updateCalibration(status *calibration.Status) {
 	for _, item := range append([]menuItem{
 		itemForceDischarge,
 		itemUninstall,
-		itemDisableLimit,
 	}, quickLimitItems...) {
 		c.menu.setEnabled(item, settingsEnabled)
 	}
+	c.menu.setEnabled(itemDisableLimit, settingsEnabled || c.disableScheduled)
 }
 
 func (c *menuController) calibrationStatusTitle(status *calibration.Status) (string, bool) {

--- a/pkg/gui/controller.go
+++ b/pkg/gui/controller.go
@@ -187,6 +187,7 @@ func (c *menuController) updateDisableSchedule(conf config.Config) {
 		return
 	}
 
+	c.menu.setEnabled(itemCalibrationStart, false)
 	c.menu.setEnabled(itemDisableLimit, true)
 	c.menu.setTitle(
 		itemDisableLimitCountdown,
@@ -265,7 +266,7 @@ func (c *menuController) updateCalibration(status *calibration.Status) {
 		c.menu.setTitle(itemAutoCalibration, "Auto Calibration (Experimental) In Progress...")
 	}
 
-	c.menu.setEnabled(itemCalibrationStart, isIdle)
+	c.menu.setEnabled(itemCalibrationStart, canStartCalibration(status.Phase, c.disableScheduled))
 	c.menu.setEnabled(itemCalibrationCancel, !isIdle)
 	c.menu.setEnabled(itemCalibrationPause, !isIdle && !status.Paused)
 	c.menu.setEnabled(itemCalibrationResume, status.Paused)
@@ -274,13 +275,30 @@ func (c *menuController) updateCalibration(status *calibration.Status) {
 	}
 
 	settingsEnabled := isIdle || status.Phase == calibration.PhaseError || status.Paused
-	for _, item := range append([]menuItem{
+	for _, item := range []menuItem{
 		itemForceDischarge,
 		itemUninstall,
-	}, quickLimitItems...) {
+	} {
 		c.menu.setEnabled(item, settingsEnabled)
 	}
-	c.menu.setEnabled(itemDisableLimit, settingsEnabled || c.disableScheduled)
+	for _, item := range quickLimitItems {
+		c.menu.setEnabled(item, canSetChargeLimit(status.Phase))
+	}
+	// A persisted conflict may contain both states after a restart. Keep the
+	// submenu openable only to show its countdown; its actions remain disabled.
+	c.menu.setEnabled(itemDisableLimit, canOpenDisableLimitMenu(status.Phase, c.disableScheduled))
+}
+
+func canStartCalibration(phase calibration.Phase, disableScheduled bool) bool {
+	return phase == calibration.PhaseIdle && !disableScheduled
+}
+
+func canOpenDisableLimitMenu(phase calibration.Phase, disableScheduled bool) bool {
+	return phase == calibration.PhaseIdle || disableScheduled
+}
+
+func canSetChargeLimit(phase calibration.Phase) bool {
+	return phase == calibration.PhaseIdle
 }
 
 func (c *menuController) calibrationStatusTitle(status *calibration.Status) (string, bool) {

--- a/pkg/gui/controller_test.go
+++ b/pkg/gui/controller_test.go
@@ -1,0 +1,38 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/charlie0129/batt/pkg/calibration"
+)
+
+func TestCalibrationAndTemporaryDisableMenuExclusion(t *testing.T) {
+	tests := []struct {
+		name               string
+		phase              calibration.Phase
+		disableScheduled   bool
+		wantCalibration    bool
+		wantDisableSubmenu bool
+		wantChargeLimits   bool
+	}{
+		{name: "both available while idle", phase: calibration.PhaseIdle, wantCalibration: true, wantDisableSubmenu: true, wantChargeLimits: true},
+		{name: "schedule blocks calibration", phase: calibration.PhaseIdle, disableScheduled: true, wantDisableSubmenu: true, wantChargeLimits: true},
+		{name: "calibration blocks temporary disable", phase: calibration.PhaseCharge},
+		{name: "failed calibration awaiting cancellation blocks temporary disable", phase: calibration.PhaseError},
+		{name: "persisted conflict keeps countdown accessible", phase: calibration.PhaseCharge, disableScheduled: true, wantDisableSubmenu: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canStartCalibration(tt.phase, tt.disableScheduled); got != tt.wantCalibration {
+				t.Errorf("canStartCalibration() = %v, want %v", got, tt.wantCalibration)
+			}
+			if got := canOpenDisableLimitMenu(tt.phase, tt.disableScheduled); got != tt.wantDisableSubmenu {
+				t.Errorf("canOpenDisableLimitMenu() = %v, want %v", got, tt.wantDisableSubmenu)
+			}
+			if got := canSetChargeLimit(tt.phase); got != tt.wantChargeLimits {
+				t.Errorf("canSetChargeLimit() = %v, want %v", got, tt.wantChargeLimits)
+			}
+		})
+	}
+}

--- a/pkg/gui/native.go
+++ b/pkg/gui/native.go
@@ -54,12 +54,39 @@ const (
 	itemQuit                    menuItem = C.BattItemQuit
 )
 
+const (
+	itemDisableLimitCountdown    menuItem = C.BattItemDisableLimitCountdown
+	itemDisableLimitIndefinitely menuItem = C.BattItemDisableLimitIndefinitely
+	itemDisableLimit1Hour        menuItem = C.BattItemDisableLimit1Hour
+	itemDisableLimit2Hours       menuItem = C.BattItemDisableLimit2Hours
+	itemDisableLimit4Hours       menuItem = C.BattItemDisableLimit4Hours
+	itemDisableLimit8Hours       menuItem = C.BattItemDisableLimit8Hours
+	itemDisableLimit12Hours      menuItem = C.BattItemDisableLimit12Hours
+	itemDisableLimit24Hours      menuItem = C.BattItemDisableLimit24Hours
+	itemDisableLimit2Days        menuItem = C.BattItemDisableLimit2Days
+	itemDisableLimit3Days        menuItem = C.BattItemDisableLimit3Days
+	itemDisableLimit7Days        menuItem = C.BattItemDisableLimit7Days
+)
+
 var quickLimitItems = []menuItem{
 	itemLimit50,
 	itemLimit60,
 	itemLimit70,
 	itemLimit80,
 	itemLimit90,
+}
+
+var disableLimitActionItems = []menuItem{
+	itemDisableLimitIndefinitely,
+	itemDisableLimit1Hour,
+	itemDisableLimit2Hours,
+	itemDisableLimit4Hours,
+	itemDisableLimit8Hours,
+	itemDisableLimit12Hours,
+	itemDisableLimit24Hours,
+	itemDisableLimit2Days,
+	itemDisableLimit3Days,
+	itemDisableLimit7Days,
 }
 
 type confirmation int

--- a/pkg/gui/native.h
+++ b/pkg/gui/native.h
@@ -39,6 +39,17 @@ typedef enum {
     BattItemVersion,
     BattItemUninstall,
     BattItemDisableLimit,
+    BattItemDisableLimitCountdown,
+    BattItemDisableLimitIndefinitely,
+    BattItemDisableLimit1Hour,
+    BattItemDisableLimit2Hours,
+    BattItemDisableLimit4Hours,
+    BattItemDisableLimit8Hours,
+    BattItemDisableLimit12Hours,
+    BattItemDisableLimit24Hours,
+    BattItemDisableLimit2Days,
+    BattItemDisableLimit3Days,
+    BattItemDisableLimit7Days,
     BattItemQuit,
 } BattMenuItem;
 

--- a/pkg/gui/native_menu.m
+++ b/pkg/gui/native_menu.m
@@ -248,6 +248,32 @@ void BattBuildMenu(BattMenuController *controller, NSString *version) {
     [advanced addItem:ActionItem(controller, @"Uninstall Daemon...", @"", BattItemUninstall)];
 
     [root addItem:[NSMenuItem separatorItem]];
-    [root addItem:ActionItem(controller, @"Disable Charging Limit", @"d", BattItemDisableLimit)];
+    NSMenu *disableLimit = AddSubmenu(controller, root, @"Disable Charge Limit",
+                                      BattItemDisableLimit);
+    NSMenuItem *disableCountdown = DisplayItem(controller, @"",
+                                                BattItemDisableLimitCountdown, NO);
+    disableCountdown.hidden = YES;
+    [disableLimit addItem:disableCountdown];
+    [disableLimit addItem:ActionItem(controller, @"Indefinitely", @"d",
+                                      BattItemDisableLimitIndefinitely)];
+    [disableLimit addItem:[NSMenuItem separatorItem]];
+    [disableLimit addItem:ActionItem(controller, @"1 Hour", @"",
+                                      BattItemDisableLimit1Hour)];
+    [disableLimit addItem:ActionItem(controller, @"2 Hours", @"",
+                                      BattItemDisableLimit2Hours)];
+    [disableLimit addItem:ActionItem(controller, @"4 Hours", @"",
+                                      BattItemDisableLimit4Hours)];
+    [disableLimit addItem:ActionItem(controller, @"8 Hours", @"",
+                                      BattItemDisableLimit8Hours)];
+    [disableLimit addItem:ActionItem(controller, @"12 Hours", @"",
+                                      BattItemDisableLimit12Hours)];
+    [disableLimit addItem:ActionItem(controller, @"24 Hours", @"",
+                                      BattItemDisableLimit24Hours)];
+    [disableLimit addItem:ActionItem(controller, @"2 Days", @"",
+                                      BattItemDisableLimit2Days)];
+    [disableLimit addItem:ActionItem(controller, @"3 Days", @"",
+                                      BattItemDisableLimit3Days)];
+    [disableLimit addItem:ActionItem(controller, @"7 Days", @"",
+                                      BattItemDisableLimit7Days)];
     [root addItem:ActionItem(controller, @"Quit Menubar App", @"q", BattItemQuit)];
 }

--- a/pkg/gui/native_tooltips.m
+++ b/pkg/gui/native_tooltips.m
@@ -52,9 +52,9 @@ void BattApplyTooltips(BattMenuController *controller) {
         @"Uninstall the batt daemon. This will remove the batt daemon from your system. You must enter your password to uninstall it.\n\n"
          "After uninstalling the batt daemon, no charging control will be present on your system and your Mac will charge to 100% as normal. The menubar app will still be present, but all options will be disabled. You can remove the menubar app by moving it to the trash.");
     SetTooltip(controller, BattItemDisableLimit,
-        @"Disable battery charge limit and let your Mac charge to 100%. This almost has the same effect as uninstalling batt, but keeps the batt daemon installed.");
+        @"Disable the battery charge limit and let your Mac charge to 100%, either indefinitely or for a selected duration. After a temporary disable, batt automatically restores your current limit.");
     SetTooltip(controller, BattItemQuit,
         @"Quit the batt menubar app, but keep the batt daemon running.\n\n"
          "Since the batt daemon is still running, batt can continue to control charging. This is useful if you don't want the menubar icon to show up, but still want to use batt. When the client is not running, you can change batt settings using the command line interface (batt). To prevent the menubar app from starting at login, you can remove it in System Settings -> General -> Login Items & Extensions -> remove batt.app from the list (do NOT remove the batt daemon).\n\n"
-         "If you want to stop batt completely (menubar app and the daemon), you can use the \"Disable Charging Limit\" command. To uninstall, you can use the \"Uninstall Daemon\" command in the Advanced menu.");
+         "If you want to stop batt completely (menubar app and the daemon), you can use the \"Disable Charge Limit\" command. To uninstall, you can use the \"Uninstall Daemon\" command in the Advanced menu.");
 }

--- a/pkg/gui/strings.go
+++ b/pkg/gui/strings.go
@@ -1,10 +1,12 @@
 package gui
 
 const (
-	quitTooltipInstalled = `Quit the batt menubar app, but keep the batt daemon running.
+	disableLimitTooltip          = `Disable the battery charge limit and let your Mac charge to 100%, either indefinitely or for a selected duration. After a temporary disable, batt automatically restores your current limit.`
+	disableLimitScheduledTooltip = `A temporary charge-limit disable is in progress. To cancel the schedule, set a charge limit.`
+	quitTooltipInstalled         = `Quit the batt menubar app, but keep the batt daemon running.
 
 Since the batt daemon is still running, batt can continue to control charging. This is useful if you don't want the menubar icon to show up, but still want to use batt. When the client is not running, you can change batt settings using the command line interface (batt). To prevent the menubar app from starting at login, you can remove it in System Settings -> General -> Login Items & Extensions -> remove batt.app from the list (do NOT remove the batt daemon).
 
-If you want to stop batt completely (menubar app and the daemon), you can use the "Disable Charging Limit" command. To uninstall, you can use the "Uninstall Daemon" command in the Advanced menu.`
+If you want to stop the batt daemon, you can use the "Disable Charge Limit" command. To uninstall, you can use the "Uninstall Daemon" command in the Advanced menu.`
 	quitTooltipNotInstalled = `Quit the batt menubar app.`
 )


### PR DESCRIPTION
- Replaced Disable Charging Limit with a Disable Charge Limit submenu containing:
  - Indefinitely
  - 1/2/4/8/12/24 hours
  - 2/3/7 days

- Timed options use the daemon-backed DisableFor API, while Indefinitely preserves the existing SetLimit(100) behavior.
- Displays the saved limit and a minute-level countdown while a temporary disable is active.
- Disables rescheduling options during an active schedule and adds guidance for cancelling it by setting a charge limit.
- Makes calibration and temporary disables mutually exclusive:
  - Calibration start is rejected while a temporary disable is pending.
  - Temporary disable and setLimit requests are rejected while calibration owns the charge limit, including paused and error-awaiting-cancel states.

  - Corresponding GUI actions are greyed out.

- Serializes charge-control transitions so concurrent requests cannot bypass conflict checks.
- Handles persisted conflicts after daemon restart by letting calibration retain ownership while the temporary-disable timer waits. The
saved limit is restored after calibration completes or is cancelled.

- Preserves paused calibration state during restart recovery instead of accidentally cancelling it in legacy charge-control mode.